### PR TITLE
feat(dex): integrate dex protocol for runtime resources

### DIFF
--- a/dex/7E-00_dex-index.md
+++ b/dex/7E-00_dex-index.md
@@ -6,10 +6,10 @@ tags: ["index", "generated"]
 ---
 
 # zenOS dex index
-> **last updated:** 2025-12-04T00:57:55.492643
+> **last updated:** 2026-01-04T21:31:40.952205
 
 | dex id | type | status | file name | urn (pe id) |
 | :--- | :--- | :--- | :--- | :--- |
-| `0x7E:0x02` | `documentation` | 🟢 | [README.md](dex/README.md) | `urn:zenos:runtime:dex-readme` |
-| `0x7E:0x01` | `script` | 🟢 | [7E-01_dex-yoinker.py](dex/7E-01_dex-yoinker.py) | `urn:zenos:ops:dex-yoinker` |
-| `0x7C:0x01` | `utility` | 🟢 | [dex.py](zen/utils/dex.py) | `urn:zenos:agents:dex-reader` |
+| `0x7E:0x02` | `documentation` | 🟢 | [README.md](/workspace/dex/README.md) | `urn:zenos:runtime:dex-readme` |
+| `0x7E:0x01` | `script` | 🟢 | [7E-01_dex-yoinker.py](/workspace/dex/7E-01_dex-yoinker.py) | `urn:zenos:ops:dex-yoinker` |
+| `0x7C:0x01` | `utility` | 🟢 | [dex.py](/workspace/zen/utils/dex.py) | `urn:zenos:agents:dex-reader` |

--- a/dex/7E-00_dex-index.md
+++ b/dex/7E-00_dex-index.md
@@ -1,0 +1,15 @@
+---
+dex_id: "0x7E:0x00"
+dex_type: "index"
+status: "active"
+tags: ["index", "generated"]
+---
+
+# zenOS dex index
+> **last updated:** 2025-12-04T00:57:55.492643
+
+| dex id | type | status | file name | urn (pe id) |
+| :--- | :--- | :--- | :--- | :--- |
+| `0x7E:0x02` | `documentation` | 🟢 | [README.md](dex/README.md) | `urn:zenos:runtime:dex-readme` |
+| `0x7E:0x01` | `script` | 🟢 | [7E-01_dex-yoinker.py](dex/7E-01_dex-yoinker.py) | `urn:zenos:ops:dex-yoinker` |
+| `0x7C:0x01` | `utility` | 🟢 | [dex.py](zen/utils/dex.py) | `urn:zenos:agents:dex-reader` |

--- a/dex/7E-01_dex-yoinker.py
+++ b/dex/7E-01_dex-yoinker.py
@@ -1,0 +1,124 @@
+"""
+---
+dex_id: "0x7E:0x01"
+dex_type: "script"
+midi_2_0_context:
+  resource_type: "Utility"
+  property_exchange_id: "urn:zenos:ops:dex-yoinker"
+legacy_map:
+  midi_1_0_bank: 126
+  midi_1_0_prog: 1
+status: "active"
+tags: ["python", "ops", "metadata", "indexing"]
+---
+"""
+
+import os
+import re
+import datetime
+from pathlib import Path
+
+# Configuration
+ROOT_DIR = Path(".") 
+DEX_DIR = ROOT_DIR / "dex"
+OUTPUT_FILE = DEX_DIR / "7E-00_dex-index.md"
+
+# Regex for YAML frontmatter
+YAML_FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
+
+# Keys to extract
+KEYS_TO_YOINK = {
+    "dex_id": re.compile(r"^dex_id:\s*[\"']?(0x[0-9A-F]{2}:0x[0-9A-F]{2})[\"']?", re.MULTILINE),
+    "dex_type": re.compile(r"^dex_type:\s*[\"']?(\w+)[\"']?", re.MULTILINE),
+    "status": re.compile(r"^status:\s*[\"']?(\w+)[\"']?", re.MULTILINE),
+    "pe_id": re.compile(r"property_exchange_id:\s*[\"']?([a-zA-Z0-9:\-\.]+)[\"']?", re.MULTILINE)
+}
+
+def parse_file(filepath):
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+        match = YAML_FRONT_RE.match(content)
+        
+        # Also check for triple-quoted string blocks (common in Python scripts)
+        if not match and filepath.suffix == '.py':
+             match = re.match(r'^\s*"""(.*?)"""', content, re.DOTALL)
+             if match:
+                 # Check if the inner content looks like frontmatter
+                 inner = match.group(1)
+                 fm_match = YAML_FRONT_RE.match(inner.strip() + "\n")
+                 if fm_match:
+                     yaml_block = fm_match.group(1)
+                 else:
+                     # Try matching without the --- delimiters if inside triple quotes
+                     yaml_block = inner
+             else:
+                 return None
+        elif match:
+            yaml_block = match.group(1)
+        else:
+            return None
+
+        metadata = {"path": str(filepath), "filename": filepath.name}
+        for key, regex in KEYS_TO_YOINK.items():
+            found = regex.search(yaml_block)
+            metadata[key] = found.group(1) if found else "N/A"
+        
+        # Only include files that actually have a dex_id
+        if metadata.get("dex_id") == "N/A":
+            return None
+            
+        return metadata
+    except Exception as e:
+        # Silently skip files we can't parse
+        return None
+
+def generate_markdown_index(entries):
+    # Sort High to Low (0x7F -> 0x00)
+    entries.sort(key=lambda x: x.get("dex_id", "0x00:00"), reverse=True)
+    
+    md_lines = [
+        "---",
+        "dex_id: \"0x7E:0x00\"",
+        "dex_type: \"index\"",
+        "status: \"active\"",
+        "tags: [\"index\", \"generated\"]",
+        "---",
+        "",
+        "# zenOS dex index",
+        f"> **last updated:** {datetime.datetime.now().isoformat()}",
+        "",
+        "| dex id | type | status | file name | urn (pe id) |",
+        "| :--- | :--- | :--- | :--- | :--- |"
+    ]
+    
+    for entry in entries:
+        if entry["dex_id"] == "N/A": continue
+        link = f"[{entry['filename']}]({entry['path']})"
+        emoji = "🟢" if entry['status'] == "active" else "⚪"
+        row = f"| `{entry['dex_id']}` | `{entry['dex_type']}` | {emoji} | {link} | `{entry['pe_id']}` |"
+        md_lines.append(row)
+        
+    return "\n".join(md_lines)
+
+def main():
+    print("🎹 starting dex yoinker...")
+    valid_entries = []
+    for root, dirs, files in os.walk(ROOT_DIR):
+        if ".git" in dirs: dirs.remove(".git")
+        if "node_modules" in dirs: dirs.remove("node_modules")
+        if "__pycache__" in dirs: dirs.remove("__pycache__")
+        
+        for file in files:
+            if file.endswith((".md", ".py", ".yaml")) and Path(root)/file != OUTPUT_FILE:
+                meta = parse_file(Path(root) / file)
+                if meta: valid_entries.append(meta)
+
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        f.write(generate_markdown_index(valid_entries))
+    print(f"✅ yoink complete. found {len(valid_entries)} entries")
+    print(f"   index: {OUTPUT_FILE}")
+
+if __name__ == "__main__":
+    main()
+

--- a/dex/7E-01_dex-yoinker.py
+++ b/dex/7E-01_dex-yoinker.py
@@ -28,7 +28,7 @@ YAML_FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE
 
 # Keys to extract
 KEYS_TO_YOINK = {
-    "dex_id": re.compile(r"^dex_id:\s*[\"']?(0x[0-9A-F]{2}:0x[0-9A-F]{2})[\"']?", re.MULTILINE),
+    "dex_id": re.compile(r"^dex_id:\s*[\"']?(0x[0-9A-Fa-f]{2}:0x[0-9A-Fa-f]{2})[\"']?", re.MULTILINE),
     "dex_type": re.compile(r"^dex_type:\s*[\"']?(\w+)[\"']?", re.MULTILINE),
     "status": re.compile(r"^status:\s*[\"']?(\w+)[\"']?", re.MULTILINE),
     "pe_id": re.compile(r"property_exchange_id:\s*[\"']?([a-zA-Z0-9:\-\.]+)[\"']?", re.MULTILINE)
@@ -69,8 +69,8 @@ def parse_file(filepath):
             return None
             
         return metadata
-    except Exception as e:
-        # Silently skip files we can't parse
+    except (OSError, UnicodeDecodeError):
+        # Skip files that can't be read or decoded
         return None
 
 def generate_markdown_index(entries):
@@ -115,7 +115,7 @@ def main():
                 if meta: valid_entries.append(meta)
 
     with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
-        f.write(generate_markdown_index(valid_entries))
+        f.write(generate_markdown_index(valid_entries) + "\n")
     print(f"✅ yoink complete. found {len(valid_entries)} entries")
     print(f"   index: {OUTPUT_FILE}")
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -45,9 +45,9 @@ both use the same protocol, different domains:
 
 ## protocol reference
 
-see the full dex protocol spec in dev-master:
-- [dex protocol spec](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7F-7F_dex-protocol-spec.md)
-- [architecture doc](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7E-02_dex-architecture.md)
+see the full dex protocol spec in dev-master (private repository):
+- dex protocol spec (`dex/7F-7F_dex-protocol-spec.md`)
+- architecture doc (`dex/7E-02_dex-architecture.md`)
 
 ## usage
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -1,0 +1,74 @@
+---
+dex_id: "0x7E:0x02"
+dex_type: "documentation"
+midi_2_0_context:
+  resource_type: "Documentation"
+  property_exchange_id: "urn:zenos:runtime:dex-readme"
+legacy_map:
+  midi_1_0_bank: 126
+  midi_1_0_prog: 2
+status: "active"
+tags: ["documentation", "dex", "zenos", "runtime"]
+---
+
+# zenOS dex integration
+
+this directory implements the dex protocol for zenOS runtime resources.
+
+## quick start
+
+```bash
+# generate/update the dex index
+python3 dex/7E-01_dex-yoinker.py
+
+# view the index
+cat dex/7E-00_dex-index.md
+```
+
+## what's indexed
+
+the yoinker scans zenOS for files with MIDI 2.0 frontmatter:
+- zen/ modules and utilities
+- scripts and tools
+- documentation with dex annotations
+- configuration files
+- anything with a `dex_id` in frontmatter
+
+## relationship to dev-master
+
+**dev-master/dex/** - protocol specification and infrastructure procedures  
+**zenOS/dex/** - runtime resources and operational catalog
+
+both use the same protocol, different domains:
+- dev-master: how to build (0x7F kernel, 0x7E ops, 0x7D dev)
+- zenOS: what's running (0x7C agents, 0x7B audio, runtime resources)
+
+## protocol reference
+
+see the full dex protocol spec in dev-master:
+- [dex protocol spec](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7F-7F_dex-protocol-spec.md)
+- [architecture doc](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7E-02_dex-architecture.md)
+
+## usage
+
+### cli integration (future)
+```bash
+zen dex list                    # list all dex entries
+zen dex get 0x7C:0x01          # get specific entry
+zen dex search --tag agents    # search by tag
+zen dex sync                    # regenerate index
+```
+
+### python api
+```python
+from zen.utils.dex import DexReader
+
+dex = DexReader()
+agents = dex.by_bank(0x7C)  # all agent resources
+spec = dex.get("0x7F:0x7F")  # specific entry
+```
+
+---
+
+*runtime resources, cataloged and discoverable*
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,7 @@ pydub>=0.25.1
 librosa>=0.9.0
 
 # Configuration
-pydantic>=1.10.0
+pydantic>=1.10.0python-dotenv>=1.0.0
+aiohttp>=3.8.0
+beautifulsoup4>=4.9.0
+schedule>=1.1.0

--- a/test_dex.py
+++ b/test_dex.py
@@ -1,0 +1,132 @@
+import unittest
+import tempfile
+import os
+from pathlib import Path
+from zen.utils.dex import DexReader, get_dex_metadata
+
+class TestDexReader(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.index_path = Path(self.test_dir.name) / "test_index.md"
+        
+        # Create a dummy index file
+        with open(self.index_path, 'w', encoding='utf-8') as f:
+            f.write("""---
+dex_id: "0x7E:0x00"
+---
+
+| dex id | type | status | file name | urn (pe id) |
+| :--- | :--- | :--- | :--- | :--- |
+| `0x7C:0x01` | `utility` | 🟢 | [dex.py](zen/utils/dex.py) | `urn:zenos:agents:dex-reader` |
+| `0x7E:0x01` | `script` | 🟢 | [yoinker.py](dex/yoinker.py) | `urn:zenos:ops:dex-yoinker` |
+""")
+        self.reader = DexReader(str(self.index_path))
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_get_by_id(self):
+        entry = self.reader.get("0x7C:0x01")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["dex_id"], "0x7C:0x01")
+        self.assertEqual(entry["type"], "utility")
+        
+        # Test non-existent
+        self.assertIsNone(self.reader.get("0x00:00"))
+
+    def test_by_bank(self):
+        entries = self.reader.by_bank(0x7C)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["dex_id"], "0x7C:0x01")
+        
+        entries_7e = self.reader.by_bank(0x7E)
+        self.assertEqual(len(entries_7e), 1)
+        self.assertEqual(entries_7e[0]["dex_id"], "0x7E:0x01")
+
+    def test_by_type(self):
+        entries = self.reader.by_type("utility")
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["dex_id"], "0x7C:0x01")
+
+    def test_search(self):
+        # Search by filename
+        results = self.reader.search("yoinker")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["filename"], "yoinker.py")
+        
+        # Search by pe_id
+        results = self.reader.search("urn:zenos:agents")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["dex_id"], "0x7C:0x01")
+
+    def test_refresh(self):
+        # Modify index
+        with open(self.index_path, 'a', encoding='utf-8') as f:
+            f.write("| `0x7F:0xFF` | `test` | 🟢 | [test.py](test.py) | `urn:test` |\n")
+        
+        self.reader.refresh()
+        entry = self.reader.get("0x7F:0xFF")
+        self.assertIsNotNone(entry)
+
+class TestGetDexMetadata(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.dir_path = Path(self.test_dir.name)
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_yaml_frontmatter(self):
+        p = self.dir_path / "test.md"
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write("""---
+dex_id: "0x12:0x34"
+dex_type: "test"
+status: "active"
+property_exchange_id: "urn:test"
+---
+content
+""")
+        meta = get_dex_metadata(p)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["dex_id"], "0x12:0x34")
+        self.assertEqual(meta["dex_type"], "test")
+
+    def test_python_docstring(self):
+        p = self.dir_path / "test.py"
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write('''"""
+---
+dex_id: "0xAB:0xCD"
+dex_type: "script"
+status: "draft"
+property_exchange_id: "urn:py:test"
+---
+"""
+print("hello")
+''')
+        meta = get_dex_metadata(p)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["dex_id"], "0xAB:0xCD")
+        self.assertEqual(meta["pe_id"], "urn:py:test")
+
+    def test_no_metadata(self):
+        p = self.dir_path / "empty.txt"
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write("just text")
+        meta = get_dex_metadata(p)
+        self.assertIsNone(meta)
+
+    def test_malformed_file(self):
+        # Should handle gracefully
+        p = self.dir_path / "bad.bin"
+        with open(p, 'wb') as f:
+            f.write(b'\x80\x81\xff') # Invalid utf-8
+        
+        # Depending on implementation, might raise or return None. 
+        # The current impl catches UnicodeDecodeError and returns None.
+        meta = get_dex_metadata(p)
+        self.assertIsNone(meta)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_dex.py
+++ b/test_dex.py
@@ -92,6 +92,20 @@ content
         self.assertEqual(meta["dex_id"], "0x12:0x34")
         self.assertEqual(meta["dex_type"], "test")
 
+    def test_lowercase_hex_id(self):
+        p = self.dir_path / "lower.md"
+        with open(p, 'w', encoding='utf-8') as f:
+            f.write("""---
+dex_id: "0x7e:0x99"
+dex_type: "test"
+status: "active"
+property_exchange_id: "urn:test"
+---
+""")
+        meta = get_dex_metadata(p)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["dex_id"], "0x7e:0x99")
+
     def test_python_docstring(self):
         p = self.dir_path / "test.py"
         with open(p, 'w', encoding='utf-8') as f:

--- a/zen/utils/dex.py
+++ b/zen/utils/dex.py
@@ -1,0 +1,145 @@
+"""
+---
+dex_id: "0x7C:0x01"
+dex_type: "utility"
+midi_2_0_context:
+  resource_type: "Library"
+  property_exchange_id: "urn:zenos:agents:dex-reader"
+legacy_map:
+  midi_1_0_bank: 124
+  midi_1_0_prog: 1
+status: "active"
+tags: ["python", "utility", "dex", "metadata"]
+---
+
+dex reader utility for zenOS
+
+provides runtime access to dex metadata from both:
+- distributed frontmatter (0xNN:0xNN format)
+- centralized registry (0xNN.NN.NN format)
+"""
+
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class DexReader:
+    """reader for dex protocol metadata"""
+    
+    def __init__(self, index_path: str = "dex/7E-00_dex-index.md"):
+        self.index_path = Path(index_path)
+        self.entries = []
+        self._load_index()
+    
+    def _load_index(self):
+        """load entries from the dex index"""
+        if not self.index_path.exists():
+            return
+        
+        with open(self.index_path, 'r') as f:
+            lines = f.readlines()
+        
+        # parse markdown table
+        in_table = False
+        for line in lines:
+            if line.startswith("| dex id"):
+                in_table = True
+                continue
+            if line.startswith("| :---"):
+                continue
+            if in_table and line.startswith("|"):
+                parts = [p.strip() for p in line.split("|")[1:-1]]
+                if len(parts) >= 5:
+                    # extract dex_id from backticks
+                    dex_id = parts[0].strip("`")
+                    entry = {
+                        "dex_id": dex_id,
+                        "type": parts[1].strip("`"),
+                        "status": "active" if "🟢" in parts[2] else "inactive",
+                        "filename": self._extract_filename(parts[3]),
+                        "path": self._extract_path(parts[3]),
+                        "pe_id": parts[4].strip("`")
+                    }
+                    self.entries.append(entry)
+    
+    def _extract_filename(self, markdown_link: str) -> str:
+        """extract filename from [text](path) format"""
+        match = re.search(r'\[(.*?)\]', markdown_link)
+        return match.group(1) if match else markdown_link
+    
+    def _extract_path(self, markdown_link: str) -> str:
+        """extract path from [text](path) format"""
+        match = re.search(r'\((.*?)\)', markdown_link)
+        return match.group(1) if match else ""
+    
+    def get(self, dex_id: str) -> Optional[Dict]:
+        """get entry by dex_id"""
+        for entry in self.entries:
+            if entry["dex_id"] == dex_id:
+                return entry
+        return None
+    
+    def by_bank(self, bank: int) -> List[Dict]:
+        """get all entries in a bank (e.g., 0x7E)"""
+        bank_hex = f"0x{bank:02X}"
+        return [e for e in self.entries if e["dex_id"].startswith(bank_hex)]
+    
+    def by_type(self, dex_type: str) -> List[Dict]:
+        """get all entries of a specific type"""
+        return [e for e in self.entries if e["type"] == dex_type]
+    
+    def search(self, query: str) -> List[Dict]:
+        """search entries by filename or pe_id"""
+        query_lower = query.lower()
+        return [
+            e for e in self.entries
+            if query_lower in e["filename"].lower()
+            or query_lower in e["pe_id"].lower()
+        ]
+    
+    def list_all(self) -> List[Dict]:
+        """return all entries"""
+        return self.entries
+    
+    def refresh(self):
+        """reload the index"""
+        self.entries = []
+        self._load_index()
+
+
+def get_dex_metadata(filepath: Path) -> Optional[Dict]:
+    """extract dex metadata from a file's frontmatter"""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # try standard frontmatter
+        match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL | re.MULTILINE)
+        
+        # try triple-quoted for python
+        if not match and filepath.suffix == '.py':
+            match = re.match(r'^\s*"""(.*?)"""', content, re.DOTALL)
+        
+        if not match:
+            return None
+        
+        yaml_block = match.group(1)
+        
+        # extract key fields
+        metadata = {}
+        patterns = {
+            "dex_id": r"^dex_id:\s*[\"']?(0x[0-9A-F]{2}:0x[0-9A-F]{2})[\"']?",
+            "dex_type": r"^dex_type:\s*[\"']?(\w+)[\"']?",
+            "status": r"^status:\s*[\"']?(\w+)[\"']?",
+            "pe_id": r"property_exchange_id:\s*[\"']?([a-zA-Z0-9:\-\.]+)[\"']?"
+        }
+        
+        for key, pattern in patterns.items():
+            found = re.search(pattern, yaml_block, re.MULTILINE)
+            metadata[key] = found.group(1) if found else None
+        
+        return metadata if metadata.get("dex_id") else None
+    except:
+        return None
+

--- a/zen/utils/dex.py
+++ b/zen/utils/dex.py
@@ -37,7 +37,7 @@ class DexReader:
         if not self.index_path.exists():
             return
         
-        with open(self.index_path, 'r') as f:
+        with open(self.index_path, 'r', encoding='utf-8') as f:
             lines = f.readlines()
         
         # parse markdown table
@@ -129,7 +129,7 @@ def get_dex_metadata(filepath: Path) -> Optional[Dict]:
         # extract key fields
         metadata = {}
         patterns = {
-            "dex_id": r"^dex_id:\s*[\"']?(0x[0-9A-F]{2}:0x[0-9A-F]{2})[\"']?",
+            "dex_id": r"^dex_id:\s*[\"']?(0x[0-9A-Fa-f]{2}:0x[0-9A-Fa-f]{2})[\"']?",
             "dex_type": r"^dex_type:\s*[\"']?(\w+)[\"']?",
             "status": r"^status:\s*[\"']?(\w+)[\"']?",
             "pe_id": r"property_exchange_id:\s*[\"']?([a-zA-Z0-9:\-\.]+)[\"']?"
@@ -140,6 +140,6 @@ def get_dex_metadata(filepath: Path) -> Optional[Dict]:
             metadata[key] = found.group(1) if found else None
         
         return metadata if metadata.get("dex_id") else None
-    except:
+    except (OSError, UnicodeDecodeError, AttributeError):
         return None
 

--- a/zen/utils/dex_constants.py
+++ b/zen/utils/dex_constants.py
@@ -1,0 +1,24 @@
+"""
+dex constants and regex patterns
+"""
+import re
+
+# Regex for YAML frontmatter
+YAML_FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
+
+# Regex for Python docstring frontmatter
+PYTHON_DOCSTRING_RE = re.compile(r'^\s*"""(.*?)"""', re.DOTALL)
+
+# Common regex patterns for field extraction
+DEX_ID_PATTERN = r"^dex_id:\s*[\"']?(0x[0-9A-Fa-f]{2}:0x[0-9A-Fa-f]{2})[\"']?"
+DEX_TYPE_PATTERN = r"^dex_type:\s*[\"']?(\w+)[\"']?"
+STATUS_PATTERN = r"^status:\s*[\"']?(\w+)[\"']?"
+PE_ID_PATTERN = r"property_exchange_id:\s*[\"']?([a-zA-Z0-9:\-\.]+)[\"']?"
+
+# Compiled regex for efficient reuse
+PATTERNS = {
+    "dex_id": re.compile(DEX_ID_PATTERN, re.MULTILINE),
+    "dex_type": re.compile(DEX_TYPE_PATTERN, re.MULTILINE),
+    "status": re.compile(STATUS_PATTERN, re.MULTILINE),
+    "pe_id": re.compile(PE_ID_PATTERN, re.MULTILINE)
+}


### PR DESCRIPTION
## overview

integrates the dex protocol (MIDI 2.0 baseline) into zenOS for runtime resource cataloging.

## what's included

### dex infrastructure
- **`dex/7E-01_dex-yoinker.py`** - yoinker script for scanning and indexing
- **`dex/README.md`** - integration documentation (0x7E:0x02)
- **`dex/7E-00_dex-index.md`** - auto-generated index (3 entries)

### runtime utilities
- **`zen/utils/dex.py`** - python module for querying dex metadata (0x7C:0x01)
  - `DexReader` class for runtime access
  - methods: `get()`, `by_bank()`, `by_type()`, `search()`
  - lightweight, no external dependencies

## integration with dev-master

follows the dual-layer architecture:
- **dev-master/dex/** - protocol specs and infrastructure docs
- **zenOS/dex/** - runtime resources and operational catalog

both use the same protocol, different domains:
- dev-master: procedures, templates, infrastructure (0x7F, 0x7E, 0x7D)
- zenOS: agents, runtime utilities, workflows (0x7C, 0x7B, runtime)

## protocol reference

see dev-master for full specs:
- [dex protocol spec](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7F-7F_dex-protocol-spec.md)
- [architecture doc](https://github.com/k-dot-greyz/dev-master/blob/main/dex/7E-02_dex-architecture.md)

## usage

### scan and index
```bash
python3 dex/7E-01_dex-yoinker.py
cat dex/7E-00_dex-index.md
```

### python api
```python
from zen.utils.dex import DexReader

dex = DexReader()
agents = dex.by_bank(0x7C)  # all agent resources
reader = dex.get('0x7C:0x01')  # specific utility
```

## next steps
- add dex frontmatter to zen/ modules
- integrate into zen cli (`zen dex` commands)
- sync with dev-master dex updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dex metadata indexing (yoinker script + generated index), a `DexReader` runtime utility, and integration documentation.
> 
> - **Indexing/Ops**:
>   - **Script**: Add `dex/7E-01_dex-yoinker.py` to scan files for dex frontmatter and generate an index.
>   - **Generated Index**: Create `dex/7E-00_dex-index.md` listing entries with `dex_id`, type, status, file link, and `pe_id`.
> - **Runtime Utility**:
>   - **`DexReader`** in `zen/utils/dex.py` to load/query the index (`get()`, `by_bank()`, `by_type()`, `search()`, `list_all()`, `refresh()`), plus `get_dex_metadata()` parser.
> - **Documentation**:
>   - Add `dex/README.md` describing zenOS dex integration, quick start, protocol references, and usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bfe84b55360ca8b009fdb14876440200651eab7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automated, sortable catalog index with CLI and programmatic access for listing, searching, filtering, and refreshing entries.

* **Documentation**
  * New guide describing catalog purpose, quick-start commands, usage examples, and indexing scope.

* **Tests**
  * Unit tests covering index parsing, retrieval, filtering, refresh, and metadata extraction edge cases.

* **Bug Fixes**
  * Fixed requirements formatting that could break dependency parsing.

* **Other**
  * Indexing reports progress and skips unreadable or non-catalog files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->