### PR TITLE
Ducks for zenOS quickstart and env dev pipeline and hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ jspm_packages/
 
 # dotenv environment variable files
 .env
+.zen-hydration/
 .env.development.local
 .env.test.local
 .env.production.local

--- a/docs/issues/ZEN-286.md
+++ b/docs/issues/ZEN-286.md
@@ -1,0 +1,148 @@
+# ZEN-286 — ducky: portable env setup & hydration for zenOS
+
+**Status:** In progress  
+**Linear:** https://linear.app/zenos/issue/ZEN-286  
+**PR:** Ducks for zenOS quickstart and env dev pipeline and hydration
+
+---
+
+## Problem
+
+zenOS has solid programmatic setup (`setup.py`, Termux installers, `EnvironmentDetector`, `SetupTroubleshooter`) but no **portable, tap-to-run payload** for:
+
+- Android (Termux widget / shared storage / USB OTG)
+- USB drives as env config carriers
+- A single entry that runs diagnostics then hydrates a local dev scaffold
+
+Operators currently need curl-pipe installers or manual clone + setup steps. There is no unified **env-doctor → hydrate → programmatic fallback** pipeline.
+
+---
+
+## Intent (from PR discussion)
+
+> Tap ducky on Android or a USB drive as env setup and config payload, starting with auto env-doctor run for local deets and hydration scaffold via dev-master if available, zenOS otherwise programmatically.
+
+### User story
+
+**As** a zenOS operator on mobile or air-gapped USB,  
+**I want** to tap/run a single ducky entrypoint,  
+**So that** my environment is diagnosed, scaffolded, and bootstrapped without memorizing install commands.
+
+### MVP acceptance criteria
+
+- [ ] `ducky/run.sh` works from repo root and USB path on Linux/macOS
+- [ ] `ducky/run.ps1` works on Windows
+- [ ] `ducky/tap-termux.sh` finds ducky on common Android storage paths
+- [ ] `ducky/env_doctor.py` emits `.zen-hydration/local-deets.json` with platform, tooling, and validation summary
+- [ ] Hydration prefers `dev-master/hydration` when present, else `ducky/hydrate/*`
+- [ ] Fallback runs `python setup.py --unattended` (or `--validate-only` for minimal profile)
+- [ ] `.zen-hydration/manifest.json` records profile, source, and timestamp
+- [ ] Documentation in `ducky/README.md` and QUICKSTART cross-link
+
+### Non-goals (defer)
+
+- Encrypted secrets on portable media
+- Full OTG auto-mount on Android without Termux/file manager
+- Creating the external `dev-master` repo (use `zenOS-dev` / `setup.py` until defined)
+- Wiring `zen doctor` into main `zen.cli` entry point (separate follow-up)
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Tap[Tap ducky / run.sh] --> Doctor[env-doctor.py]
+  Doctor --> Deets[.zen-hydration/local-deets.json]
+  Doctor --> Hydrate{hydration source?}
+  Hydrate -->|dev-master found| DM[dev-master/hydration]
+  Hydrate -->|else| Templates[ducky/hydrate/profile]
+  DM --> Manifest[.zen-hydration/manifest.json]
+  Templates --> Manifest
+  Manifest --> Setup{profile}
+  Setup -->|minimal| Validate[setup.py --validate-only]
+  Setup -->|developer/mobile| Unattended[setup.py --unattended]
+  Setup -->|offline| Offline[setup-offline.sh]
+```
+
+---
+
+## Hydration profiles
+
+| Profile | Use case | Templates | Setup |
+|---------|----------|-----------|-------|
+| `minimal` | Quick check + `.env` stub | `hydrate/default` | validate-only |
+| `developer` | Default dev machine | `hydrate/default` | unattended |
+| `mobile` | Termux / Pixel | `hydrate/mobile` | unattended |
+| `offline` | No network | `hydrate/default` | setup-offline |
+
+### Scaffold materialized (no secrets committed)
+
+- `.env` — empty key placeholder from `env.template`
+- `AGENTS.md` — post-hydration agent instructions
+- `workspace/current/` — active work dir
+- `agents/local.yaml` — local agent manifest stub
+- `integrations/mcp-config.link` — pointer to sibling MCP repo
+- `termux-aliases.sh` / widget script (mobile profile)
+
+---
+
+## Existing building blocks (reuse, don't rewrite)
+
+| Component | Location | Role in ducky |
+|-----------|----------|---------------|
+| Environment detection | `zen/setup/environment_detector.py` | env-doctor platform block |
+| Validation | `zen/setup/troubleshooter.py` | env-doctor issues |
+| Programmatic setup | `setup.py` → `zen/setup/unified_setup.py` | fallback bootstrap |
+| Health check | `zen/cli_v2.py` `doctor` | post-hydration verification |
+| Termux install | `scripts/termux-install.sh` | reference for mobile widgets |
+| Private dev repo | `scripts/private-dev.sh` → `zenOS-dev` | future dev-master stand-in |
+
+---
+
+## Implementation phases
+
+### Phase 1 — ducky MVP (this PR)
+
+- `ducky/` directory with manifest, env-doctor, run scripts, hydrate templates
+- `docs/issues/ZEN-286.md` (this file)
+
+### Phase 2 — dev-master contract
+
+- Define `dev-master` repo URL, `hydration/` tree schema
+- Auto-detect + clone if missing (optional `ZEN_DEV_MASTER` override)
+
+### Phase 3 — CLI integration
+
+- `zen env-doctor` alias on main CLI
+- Merge `cli_v2 doctor` into `zen.cli`
+- QUICKSTART_TERMUX ducky widget section
+
+---
+
+## Test plan
+
+```bash
+# env-doctor
+python ducky/env_doctor.py
+test -f .zen-hydration/local-deets.json
+
+# full pipeline (developer)
+bash ducky/run.sh
+test -f .zen-hydration/manifest.json
+test -f AGENTS.md
+
+# minimal profile
+DUCKY_PROFILE=minimal bash ducky/run.sh
+
+# mobile profile (on Termux)
+DUCKY_PROFILE=mobile bash ducky/run.sh
+```
+
+---
+
+## Open questions
+
+1. **dev-master vs zenOS-dev** — Is `dev-master` a separate repo from `k-dot-greyz/dev-master` on GitHub, or an alias for `zenOS-dev`?
+2. **USB layout** — Should the USB root be `ducky/` only or full `zenOS/` clone?
+3. **Secrets on media** — Placeholder-only for MVP; encrypted payload later?

--- a/ducky/README.md
+++ b/ducky/README.md
@@ -1,0 +1,93 @@
+# 🦆 ducky — portable zenOS env setup payload
+
+**ducky** is a tap-to-run env setup and hydration bundle for zenOS. Copy it to a USB drive or Android shared storage, run once, and get local diagnostics plus a scaffolded dev workspace.
+
+## What it does
+
+1. **env-doctor** — collects local deets (OS, shell, Python, git, Termux, `.env` presence, validation issues) into `.zen-hydration/local-deets.json`
+2. **hydrate** — materializes scaffold files from `dev-master` if available, else `ducky/hydrate/*` templates
+3. **programmatic setup** — falls back to `python setup.py --unattended` (or `--validate-only` for `minimal` profile)
+
+## Quick start
+
+### Desktop / USB (Linux/macOS)
+
+```bash
+git clone https://github.com/k-dot-greyz/zenOS.git
+cd zenOS
+bash ducky/run.sh
+```
+
+From a USB mount:
+
+```bash
+bash /media/$USER/USB/zenOS/ducky/run.sh
+```
+
+### Windows
+
+```powershell
+cd zenOS
+.\ducky\run.ps1
+```
+
+### Android (Termux)
+
+```bash
+# Copy zenOS to shared storage or clone on device
+termux-setup-storage
+cd ~/zenOS
+DUCKY_PROFILE=mobile bash ducky/run.sh
+```
+
+**Widget shortcut:** point Termux:Widget at `ducky/tap-termux.sh` or `ducky/hydrate/mobile/termux-widget-ducky.sh`.
+
+## Profiles
+
+| Profile | Hydration | Setup |
+|---------|-----------|-------|
+| `minimal` | default templates | `setup.py --validate-only` |
+| `developer` (default) | default templates | `setup.py --unattended` |
+| `mobile` | mobile templates + aliases | `setup.py --unattended` |
+| `offline` | default templates | `scripts/setup-offline.sh` |
+
+```bash
+DUCKY_PROFILE=mobile bash ducky/run.sh
+```
+
+## dev-master hydration
+
+If a sibling `dev-master` repo exists with a `hydration/` directory, ducky prefers it over in-repo templates:
+
+```bash
+export ZEN_DEV_MASTER=/path/to/dev-master
+bash ducky/run.sh
+```
+
+Checked paths (in order):
+
+- `$ZEN_DEV_MASTER/hydration`
+- `../dev-master/hydration`
+- `../../dev-master/hydration`
+
+## Outputs
+
+| File | Purpose |
+|------|---------|
+| `.zen-hydration/local-deets.json` | Machine-readable local environment report |
+| `.zen-hydration/ducky-report.json` | Same report (doctor artifact) |
+| `.zen-hydration/manifest.json` | Hydration profile, source, timestamp |
+
+## env-doctor only
+
+```bash
+python ducky/env_doctor.py
+python ducky/env_doctor.py --json-only
+```
+
+## Related
+
+- Linear: [ZEN-286](https://linear.app/zenos/issue/ZEN-286)
+- `docs/issues/ZEN-286.md` — full issue hydration
+- `docs/guides/QUICKSTART_TERMUX.md` — Termux install guide
+- `setup.py` — programmatic fallback setup

--- a/ducky/ducky.yaml
+++ b/ducky/ducky.yaml
@@ -1,0 +1,52 @@
+# ducky — portable zenOS env setup & hydration payload
+# Tap on Android (Termux) or run from USB to bootstrap a dev environment.
+
+name: ducky
+version: 0.1.0
+description: Portable env setup, local diagnostics, and hydration scaffold for zenOS
+
+default_profile: developer
+
+profiles:
+  minimal:
+    description: env-doctor + .env scaffold + pip install
+    hydrate: hydrate/default
+    setup: validate-only
+
+  developer:
+    description: Full dev scaffold with workspace dirs and MCP pointers
+    hydrate: hydrate/default
+    setup: unattended
+
+  mobile:
+    description: Termux aliases, wake-lock hooks, widget scripts
+    hydrate: hydrate/mobile
+    setup: unattended
+
+  offline:
+    description: Offline model hooks via setup-offline.sh
+    hydrate: hydrate/default
+    setup: offline
+
+hydration_sources:
+  # Checked in order; first match wins
+  - type: path
+    name: dev-master
+    paths:
+      - "${ZEN_DEV_MASTER}"
+      - "../dev-master"
+      - "../../dev-master"
+    hydrate_dir: hydration
+  - type: repo
+    name: zenOS-dev
+    url: "https://github.com/k-dot-greyz/zenOS-dev.git"
+    branch: development
+    hydrate_dir: hydration
+  - type: fallback
+    name: zenos-programmatic
+    entry: setup.py
+
+outputs:
+  local_deets: ".zen-hydration/local-deets.json"
+  manifest: ".zen-hydration/manifest.json"
+  doctor_report: ".zen-hydration/ducky-report.json"

--- a/ducky/env_doctor.py
+++ b/ducky/env_doctor.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+env-doctor — local environment diagnostics for ducky payloads.
+
+Wraps zenOS EnvironmentDetector + SetupTroubleshooter and emits machine-readable
+local deets for hydration orchestration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Resolve zenOS root (parent of ducky/)
+DUCKY_ROOT = Path(__file__).resolve().parent
+ZENOS_ROOT = DUCKY_ROOT.parent
+SETUP_ROOT = ZENOS_ROOT / "zen" / "setup"
+sys.path.insert(0, str(SETUP_ROOT))
+
+# Import setup modules directly to avoid zen package __init__ side effects
+from environment_detector import EnvironmentDetector  # noqa: E402
+from troubleshooter import SetupTroubleshooter  # noqa: E402
+
+
+def _env_presence() -> dict[str, Any]:
+    env_path = ZENOS_ROOT / ".env"
+    example_path = ZENOS_ROOT / "env.example"
+    return {
+        "env_file_exists": env_path.exists(),
+        "env_example_exists": example_path.exists(),
+        "openrouter_key_configured": bool(
+            os.environ.get("OPENROUTER_API_KEY")
+            and os.environ.get("OPENROUTER_API_KEY") not in ("", "your-api-key-here", "sk-or-v1-your-api-key-here")
+        ),
+    }
+
+
+def _pokedex_status() -> dict[str, bool]:
+    return {
+        "models_yaml": (ZENOS_ROOT / "pokedex" / "models.yaml").exists(),
+        "procedures_yaml": (ZENOS_ROOT / "pokedex" / "procedures.yaml").exists(),
+        "arena_rankings_yaml": (ZENOS_ROOT / "pokedex" / "arena_rankings.yaml").exists(),
+    }
+
+
+def _hydration_source_hints() -> dict[str, Any]:
+    candidates: list[dict[str, str]] = []
+    for label, raw in (
+        ("ZEN_DEV_MASTER", os.environ.get("ZEN_DEV_MASTER", "")),
+        ("../dev-master", str((ZENOS_ROOT / "../dev-master").resolve())),
+        ("../../dev-master", str((ZENOS_ROOT / "../../dev-master").resolve())),
+    ):
+        if not raw:
+            continue
+        path = Path(raw)
+        candidates.append(
+            {
+                "label": label,
+                "path": str(path),
+                "exists": path.is_dir(),
+                "has_hydration": (path / "hydration").is_dir() if path.is_dir() else False,
+            }
+        )
+    return {"candidates": candidates}
+
+
+def collect_local_deets(zenos_root: Path | None = None) -> dict[str, Any]:
+    root = zenos_root or ZENOS_ROOT
+    detector = EnvironmentDetector()
+    env_info = detector.detect_environment(root)
+    troubleshooter = SetupTroubleshooter()
+    validation = troubleshooter.validate_system(env_info)
+
+    issues = []
+    for item in validation.get("issues", []):
+        issues.append(
+            {
+                "message": getattr(item, "message", str(item)),
+                "fix_command": getattr(item, "fix_command", None),
+            }
+        )
+
+    return {
+        "schema": "zenos.ducky.local-deets/v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "zenos_root": str(root),
+        "ducky_root": str(DUCKY_ROOT),
+        "platform": {
+            "name": env_info.platform,
+            "shell": env_info.shell,
+            "python_version": env_info.python_version,
+            "is_termux": env_info.is_termux,
+            "is_windows": env_info.is_windows,
+            "is_macos": env_info.is_macos,
+            "is_linux": env_info.is_linux,
+            "git_available": env_info.git_available,
+            "node_available": env_info.node_available,
+            "user_home": str(env_info.user_home),
+        },
+        "env": _env_presence(),
+        "pokedex": _pokedex_status(),
+        "validation": {
+            "passed": validation.get("validations_passed", 0),
+            "total": validation.get("validations_total", 0),
+            "issue_count": validation.get("total_issues", 0),
+            "issues": issues,
+        },
+        "hydration_hints": _hydration_source_hints(),
+    }
+
+
+def write_reports(
+    deets: dict[str, Any],
+    output_dir: Path,
+) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    local_path = output_dir / "local-deets.json"
+    report_path = output_dir / "ducky-report.json"
+
+    local_path.write_text(json.dumps(deets, indent=2) + "\n", encoding="utf-8")
+    report_path.write_text(json.dumps(deets, indent=2) + "\n", encoding="utf-8")
+    return local_path, report_path
+
+
+def print_summary(deets: dict[str, Any]) -> None:
+    platform = deets["platform"]
+    print("\n🦆 ducky env-doctor\n")
+    print(f"  Platform:  {platform['name']} ({platform['shell']})")
+    print(f"  Python:    {platform['python_version']}")
+    print(f"  Termux:    {'yes' if platform['is_termux'] else 'no'}")
+    print(f"  Git:       {'yes' if platform['git_available'] else 'no'}")
+    print(f"  Node:      {'yes' if platform['node_available'] else 'no'}")
+    print(f"  .env:      {'found' if deets['env']['env_file_exists'] else 'missing'}")
+    print(
+        f"  API key:   {'configured' if deets['env']['openrouter_key_configured'] else 'not configured'}"
+    )
+    print(
+        f"  Checks:    {deets['validation']['passed']}/{deets['validation']['total']} passed"
+    )
+    if deets["validation"]["issue_count"]:
+        print(f"  Issues:    {deets['validation']['issue_count']} need attention")
+    print()
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ducky env-doctor — local environment diagnostics")
+    parser.add_argument(
+        "--zenos-root",
+        type=Path,
+        default=ZENOS_ROOT,
+        help="zenOS repository root (default: parent of ducky/)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ZENOS_ROOT / ".zen-hydration",
+        help="Directory for JSON reports",
+    )
+    parser.add_argument("--json-only", action="store_true", help="Suppress human summary")
+    args = parser.parse_args()
+
+    deets = collect_local_deets(args.zenos_root)
+    local_path, report_path = write_reports(deets, args.output_dir)
+
+    if not args.json_only:
+        print_summary(deets)
+        print(f"  Wrote: {local_path}")
+        print(f"  Wrote: {report_path}")
+
+    return 0 if deets["validation"]["issue_count"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ducky/hydrate.sh
+++ b/ducky/hydrate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# hydrate.sh — scaffold local workspace from dev-master, zenOS-dev, or ducky templates
+
+set -euo pipefail
+
+DUCKY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZENOS_ROOT="$(cd "${DUCKY_ROOT}/.." && pwd)"
+HYDRATION_DIR="${ZENOS_ROOT}/.zen-hydration"
+PROFILE="${DUCKY_PROFILE:-developer}"
+SOURCE_NAME="zenos-programmatic"
+SOURCE_PATH=""
+
+log() { printf '🦆 %s\n' "$*"; }
+
+resolve_hydration_source() {
+  if [[ -n "${ZEN_DEV_MASTER:-}" && -d "${ZEN_DEV_MASTER}/hydration" ]]; then
+    SOURCE_NAME="dev-master"
+    SOURCE_PATH="${ZEN_DEV_MASTER}/hydration"
+    return 0
+  fi
+
+  for candidate in "${ZENOS_ROOT}/../dev-master" "${ZENOS_ROOT}/../../dev-master"; do
+    if [[ -d "${candidate}/hydration" ]]; then
+      SOURCE_NAME="dev-master"
+      SOURCE_PATH="${candidate}/hydration"
+      return 0
+    fi
+  done
+
+  case "${PROFILE}" in
+    mobile)
+      SOURCE_PATH="${DUCKY_ROOT}/hydrate/mobile"
+      ;;
+    *)
+      SOURCE_PATH="${DUCKY_ROOT}/hydrate/default"
+      ;;
+  esac
+}
+
+materialize_template() {
+  local src="$1"
+  local dest="$2"
+  if [[ -e "${dest}" ]]; then
+    log "skip (exists): ${dest#${ZENOS_ROOT}/}"
+    return 0
+  fi
+  mkdir -p "$(dirname "${dest}")"
+  if [[ -d "${src}" ]]; then
+    cp -R "${src}" "${dest}"
+  else
+    cp "${src}" "${dest}"
+  fi
+  log "created: ${dest#${ZENOS_ROOT}/}"
+}
+
+hydrate_from_dir() {
+  local template_dir="$1"
+  if [[ ! -d "${template_dir}" ]]; then
+    log "template dir missing: ${template_dir}"
+    return 1
+  fi
+
+  while IFS= read -r -d '' file; do
+    rel="${file#${template_dir}/}"
+    dest_rel="${rel}"
+    if [[ "${rel}" == "env.template" ]]; then
+      dest_rel=".env"
+    fi
+    materialize_template "${file}" "${ZENOS_ROOT}/${dest_rel}"
+  done < <(find "${template_dir}" -type f -print0)
+}
+
+write_manifest() {
+  local timestamp
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "${HYDRATION_DIR}"
+  cat > "${HYDRATION_DIR}/manifest.json" <<EOF
+{
+  "schema": "zenos.ducky.hydration-manifest/v1",
+  "hydrated_at": "${timestamp}",
+  "profile": "${PROFILE}",
+  "source": "${SOURCE_NAME}",
+  "source_path": "${SOURCE_PATH}",
+  "zenos_root": "${ZENOS_ROOT}"
+}
+EOF
+  log "wrote manifest: .zen-hydration/manifest.json"
+}
+
+main() {
+  log "hydration profile: ${PROFILE}"
+  resolve_hydration_source
+  log "hydration source: ${SOURCE_NAME} (${SOURCE_PATH})"
+  hydrate_from_dir "${SOURCE_PATH}"
+  write_manifest
+}
+
+main "$@"

--- a/ducky/hydrate/default/AGENTS.md
+++ b/ducky/hydrate/default/AGENTS.md
@@ -1,0 +1,10 @@
+# Local agent onboarding (hydrated by ducky)
+
+After hydration:
+
+1. Run `python ducky/env_doctor.py` or `bash ducky/run.sh`
+2. Add your API key to `.env`
+3. Run `zen doctor --ai-mode` (or `python -m zen.cli_v2 doctor --ai-mode`)
+4. See `docs/AI_INSTRUCTIONS.md` for full protocol
+
+Hydration profile and source are recorded in `.zen-hydration/manifest.json`.

--- a/ducky/hydrate/default/agents/local.yaml
+++ b/ducky/hydrate/default/agents/local.yaml
@@ -1,0 +1,2 @@
+# Local agent manifest (hydrated stub)
+agents: []

--- a/ducky/hydrate/default/env.template
+++ b/ducky/hydrate/default/env.template
@@ -1,0 +1,3 @@
+# Hydrated after ducky run. Do not commit secrets.
+
+OPENROUTER_API_KEY=

--- a/ducky/hydrate/default/integrations/mcp-config.link
+++ b/ducky/hydrate/default/integrations/mcp-config.link
@@ -1,0 +1,5 @@
+# MCP config sibling repo pointer
+# Clone https://github.com/k-dot-greyz/mcp-config next to zenOS and symlink or set MCP_CONFIG_ROOT.
+
+sibling_path: ../mcp-config
+env_var: MCP_CONFIG_ROOT

--- a/ducky/hydrate/default/workspace/current/.gitkeep
+++ b/ducky/hydrate/default/workspace/current/.gitkeep
@@ -1,0 +1,3 @@
+# Local workspace — hydrated by ducky
+
+Put active project work here. See `workspace/README.md` in zenOS for conventions.

--- a/ducky/hydrate/mobile/env.template
+++ b/ducky/hydrate/mobile/env.template
@@ -1,0 +1,3 @@
+# Hydrated after ducky mobile profile. Do not commit secrets.
+
+OPENROUTER_API_KEY=

--- a/ducky/hydrate/mobile/termux-aliases.sh
+++ b/ducky/hydrate/mobile/termux-aliases.sh
@@ -1,0 +1,11 @@
+# Termux aliases — source from ~/.bashrc after ducky mobile hydration
+#   source ~/zenOS/ducky/hydrate/mobile/termux-aliases.sh
+
+alias zchat='zen chat'
+alias zdoc='python ~/zenOS/ducky/env_doctor.py'
+alias zduck='bash ~/zenOS/ducky/run.sh'
+alias zwake='termux-wake-lock'
+
+if command -v termux-wake-lock >/dev/null 2>&1; then
+  termux-wake-lock || true
+fi

--- a/ducky/hydrate/mobile/termux-widget-ducky.sh
+++ b/ducky/hydrate/mobile/termux-widget-ducky.sh
@@ -1,0 +1,3 @@
+# Termux widget shortcut — run ducky mobile profile
+
+DUCKY_PROFILE=mobile bash "${HOME}/zenOS/ducky/run.sh"

--- a/ducky/run.ps1
+++ b/ducky/run.ps1
@@ -1,0 +1,55 @@
+# ducky/run.ps1 — USB / Windows tap-to-bootstrap entry
+
+param(
+    [string]$Profile = $(if ($env:DUCKY_PROFILE) { $env:DUCKY_PROFILE } else { "developer" })
+)
+
+$ErrorActionPreference = "Stop"
+$DuckyRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ZenOSRoot = Split-Path -Parent $DuckyRoot
+$env:DUCKY_PROFILE = $Profile
+
+function Log($msg) { Write-Host "🦆 $msg" }
+
+Log "ducky quickstart — zenOS env pipeline"
+Log "zenOS root: $ZenOSRoot"
+Log "profile: $Profile"
+
+Log "running env-doctor"
+python "$DuckyRoot\env_doctor.py" --zenos-root $ZenOSRoot
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "env-doctor reported issues — continuing hydration"
+}
+
+Log "hydrating scaffold"
+& bash "$DuckyRoot\hydrate.sh"
+if ($LASTEXITCODE -ne 0) {
+    throw "hydrate.sh failed"
+}
+
+if (Test-Path "$ZenOSRoot\setup.py") {
+    switch ($Profile) {
+        "minimal" {
+            Log "running programmatic setup: validate-only"
+            Push-Location $ZenOSRoot
+            python setup.py --validate-only
+            Pop-Location
+        }
+        "offline" {
+            Log "running offline setup hooks"
+            if (Test-Path "$ZenOSRoot\scripts\setup-offline.sh") {
+                bash "$ZenOSRoot\scripts\setup-offline.sh"
+            }
+        }
+        default {
+            Log "running programmatic setup: unattended"
+            Push-Location $ZenOSRoot
+            python setup.py --unattended
+            Pop-Location
+        }
+    }
+} else {
+    Write-Warning "setup.py not found — clone zenOS first"
+}
+
+Log "done — check .zen-hydration\ for local deets + manifest"

--- a/ducky/run.sh
+++ b/ducky/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ducky/run.sh — tap-to-bootstrap entry for USB drives and Termux
+#
+# Usage:
+#   bash ducky/run.sh                  # default developer profile
+#   DUCKY_PROFILE=mobile bash ducky/run.sh
+#   bash /storage/emulated/0/ducky/run.sh   # from USB / shared storage on Android
+
+set -euo pipefail
+
+DUCKY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZENOS_ROOT="$(cd "${DUCKY_ROOT}/.." && pwd)"
+PROFILE="${DUCKY_PROFILE:-developer}"
+
+log() { printf '🦆 %s\n' "$*"; }
+warn() { printf '⚠️  %s\n' "$*" >&2; }
+
+detect_termux() {
+  [[ -n "${TERMUX_VERSION:-}" || -d /data/data/com.termux ]]
+}
+
+termux_bootstrap() {
+  if ! detect_termux; then
+    return 0
+  fi
+  log "Termux detected — ensuring storage + wake lock"
+  if command -v termux-setup-storage >/dev/null 2>&1; then
+    termux-setup-storage >/dev/null 2>&1 || true
+  fi
+  if command -v termux-wake-lock >/dev/null 2>&1; then
+    termux-wake-lock || true
+  fi
+}
+
+run_env_doctor() {
+  log "running env-doctor"
+  python3 "${DUCKY_ROOT}/env_doctor.py" --zenos-root "${ZENOS_ROOT}" || {
+    warn "env-doctor reported issues — continuing hydration"
+    return 0
+  }
+}
+
+run_hydration() {
+  log "hydrating scaffold (profile=${PROFILE})"
+  DUCKY_PROFILE="${PROFILE}" bash "${DUCKY_ROOT}/hydrate.sh"
+}
+
+run_programmatic_setup() {
+  if [[ ! -f "${ZENOS_ROOT}/setup.py" ]]; then
+    warn "setup.py not found — clone zenOS into ${ZENOS_ROOT} first"
+    return 1
+  fi
+
+  case "${PROFILE}" in
+    minimal)
+      log "running programmatic setup: validate-only"
+      (cd "${ZENOS_ROOT}" && python3 setup.py --validate-only) || true
+      ;;
+    offline)
+      log "running offline setup hooks"
+      if [[ -x "${ZENOS_ROOT}/scripts/setup-offline.sh" ]]; then
+        bash "${ZENOS_ROOT}/scripts/setup-offline.sh"
+      else
+        warn "scripts/setup-offline.sh not found"
+      fi
+      ;;
+    *)
+      log "running programmatic setup: unattended"
+      (cd "${ZENOS_ROOT}" && python3 setup.py --unattended) || {
+        warn "unattended setup had issues — run python setup.py manually"
+        return 0
+      }
+      ;;
+  esac
+}
+
+main() {
+  log "ducky quickstart — zenOS env pipeline"
+  log "zenOS root: ${ZENOS_ROOT}"
+  termux_bootstrap
+  run_env_doctor
+  run_hydration
+  run_programmatic_setup
+  log "done — check .zen-hydration/ for local deets + manifest"
+  log "next: zen doctor --ai-mode  (or python -m zen.cli_v2 doctor --ai-mode)"
+}
+
+main "$@"

--- a/ducky/tap-termux.sh
+++ b/ducky/tap-termux.sh
@@ -1,0 +1,25 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# tap-termux.sh — Termux home-screen widget / shortcut target
+# Point your Termux:Widget shortcut at this script after copying ducky to storage.
+
+set -euo pipefail
+
+# Common mount points when ducky lives on shared storage or USB OTG
+CANDIDATES=(
+  "${HOME}/storage/shared/ducky/run.sh"
+  "${HOME}/storage/downloads/ducky/run.sh"
+  "${HOME}/storage/documents/ducky/run.sh"
+  "${HOME}/zenOS/ducky/run.sh"
+  "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run.sh"
+)
+
+for candidate in "${CANDIDATES[@]}"; do
+  if [[ -f "${candidate}" ]]; then
+    export DUCKY_PROFILE="${DUCKY_PROFILE:-mobile}"
+    exec bash "${candidate}"
+  fi
+done
+
+echo "🦆 ducky not found. Copy zenOS (with ducky/) to one of:"
+printf '  - %s\n' "${CANDIDATES[@]}"
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **ducky** — a portable, tap-to-run env setup payload for zenOS.

**User intent:** Tap ducky on Android or a USB drive as env setup/config payload → auto env-doctor for local deets → hydration scaffold via `dev-master` if available, zenOS programmatic setup otherwise.

## What ships in this PR

### `ducky/` — portable payload

| File | Role |
|------|------|
| `run.sh` / `run.ps1` | USB + desktop entry (doctor → hydrate → setup) |
| `tap-termux.sh` | Termux widget shortcut; finds ducky on shared storage |
| `env_doctor.py` | Machine-readable local deets via `EnvironmentDetector` + `SetupTroubleshooter` |
| `hydrate.sh` | Materializes scaffold; prefers `dev-master/hydration`, else `ducky/hydrate/*` |
| `ducky.yaml` | Manifest: profiles, hydration source order, output paths |
| `hydrate/default/` | Developer scaffold (AGENTS.md, workspace, agents stub, MCP pointer) |
| `hydrate/mobile/` | Termux aliases + widget script |

### Pipeline

```
tap/run → env-doctor → hydrate (dev-master | templates) → setup.py fallback
```

Outputs land in `.zen-hydration/`:
- `local-deets.json` — platform, tooling, validation issues
- `manifest.json` — profile, hydration source, timestamp

### Docs

- `docs/issues/ZEN-286.md` — hydrated issue spec (acceptance criteria, architecture, phases)
- `ducky/README.md` — operator quickstart

## Quick test

```bash
python ducky/env_doctor.py
DUCKY_PROFILE=minimal bash ducky/run.sh
ls .zen-hydration/
```

## Profiles

| Profile | Hydration | Setup fallback |
|---------|-----------|----------------|
| `minimal` | default | `setup.py --validate-only` |
| `developer` (default) | default | `setup.py --unattended` |
| `mobile` | mobile templates | `setup.py --unattended` |
| `offline` | default | `scripts/setup-offline.sh` |

## Reused building blocks (not rewritten)

- `zen/setup/environment_detector.py`
- `zen/setup/troubleshooter.py`
- `setup.py` → `zen/setup/unified_setup.py`
- Termux patterns from `scripts/termux-install.sh`

## Deferred (follow-up PRs)

- [ ] Define external `dev-master` repo contract + auto-clone
- [ ] `zen env-doctor` on main CLI (`zen.cli`)
- [ ] Merge `cli_v2 doctor` into primary entry point
- [ ] QUICKSTART_TERMUX ducky widget section
- [ ] Encrypted secrets on portable media

## Open questions

1. Is **dev-master** a separate repo from `zenOS-dev`, or the same thing under a different name?
2. Should USB root be **ducky-only** or a full **zenOS clone**?
3. OK to keep `.env` as `env.template` in hydrate dirs (gitignore-safe)?

## Type of change

- [x] New feature
- [x] Documentation update

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-784bc33b-5d3c-4436-84a4-2a6c34666ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-784bc33b-5d3c-4436-84a4-2a6c34666ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

