### PR TITLE
feat(wiki): integrate visual-wiki knowledge garden into zenOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "integrations/visual-wiki"]
-	path = integrations/visual-wiki
-	url = https://github.com/k-dot-greyz/visual-wiki.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "integrations/visual-wiki"]
+	path = integrations/visual-wiki
+	url = https://github.com/k-dot-greyz/visual-wiki.git

--- a/README.md
+++ b/README.md
@@ -49,7 +49,20 @@ zen notes search "topic"    # Find relevant information
 zen context sync            # Update working context
 ```
 
-### 4. **Repo Management**
+### 5. **Visual Wiki (Knowledge Garden)**
+Curate links and docs in a visual card UI, then feed agents via CLI sync ([visual-wiki](https://github.com/k-dot-greyz/visual-wiki) submodule):
+
+```bash
+zen wiki setup              # Init submodule + npm install
+zen wiki dev                # Open the garden at http://localhost:3000
+zen wiki sync               # Export to ~/.zenOS/context for agent prompts
+zen wiki pipe <url>         # Ingest a link via /api/pipe (with dev server running)
+zen wiki export             # JSON export (same shape as the web UI)
+```
+
+Set `ZEN_VISUAL_WIKI_PATH` to point at a standalone clone if you are not using the submodule.
+
+### 6. **Repo Management**
 Intelligent repository analysis and organization:
 ```bash
 zen repo analyze            # Deep dive into codebase

--- a/README.md
+++ b/README.md
@@ -50,17 +50,16 @@ zen context sync            # Update working context
 ```
 
 ### 5. **Visual Wiki (Knowledge Garden)**
-Curate links and docs in a visual card UI, then feed agents via CLI sync ([visual-wiki](https://github.com/k-dot-greyz/visual-wiki) submodule):
+Curate links in the standalone [visual-wiki](https://github.com/k-dot-greyz/visual-wiki) app (submodule lives under **dev-master** at `dex/09-repos/visual-wiki`, not inside zenOS). zenOS connects via CLI + synced agent context:
 
 ```bash
-zen wiki setup              # Init submodule + npm install
-zen wiki dev                # Open the garden at http://localhost:3000
+zen wiki setup              # Clone to ~/.zenOS/visual-wiki (or use dev-master checkout)
+zen wiki dev                # http://localhost:3000
 zen wiki sync               # Export to ~/.zenOS/context for agent prompts
-zen wiki pipe <url>         # Ingest a link via /api/pipe (with dev server running)
-zen wiki export             # JSON export (same shape as the web UI)
+zen wiki pipe <url>         # Ingest via /api/pipe (dev server running)
 ```
 
-Set `ZEN_VISUAL_WIKI_PATH` to point at a standalone clone if you are not using the submodule.
+Set `ZEN_VISUAL_WIKI_PATH` to your checkout, or `DEV_MASTER_ROOT` so zen can find `dex/09-repos/visual-wiki`.
 
 ### 6. **Repo Management**
 Intelligent repository analysis and organization:

--- a/test_wiki_simple.py
+++ b/test_wiki_simple.py
@@ -9,12 +9,14 @@ sys.path.insert(0, ".")
 
 
 def test_imports():
-    from zen.wiki import build_agent_export, load_resources, resolve_visual_wiki_root
+    from zen.wiki import build_agent_export, locate_visual_wiki, resolve_visual_wiki_root
     from zen.wiki.cli import wiki
 
     assert wiki is not None
     root = resolve_visual_wiki_root(Path.cwd())
     assert root.name == "visual-wiki"
+    _path, label = locate_visual_wiki(Path.cwd())
+    assert isinstance(label, str)
 
 
 def test_export_shape():
@@ -37,20 +39,47 @@ def test_export_shape():
     assert "https://example.com" in prompt
 
 
+def test_locate_dev_master_monkeypatch(monkeypatch=None):
+    from zen.wiki import paths as wiki_paths
+
+    fake_dm = Path("/tmp/fake-dev-master")
+    wiki_path = fake_dm / "dex" / "09-repos" / "visual-wiki"
+    try:
+        wiki_path.mkdir(parents=True)
+        (wiki_path / "package.json").write_text("{}", encoding="utf-8")
+        original = wiki_paths.dev_master_root
+
+        def _fake_root():
+            return fake_dm
+
+        wiki_paths.dev_master_root = _fake_root
+        found, source = wiki_paths.locate_visual_wiki()
+        assert found == wiki_path.resolve()
+        assert "dev-master" in source
+    finally:
+        if "original" in dir():
+            wiki_paths.dev_master_root = original
+        shutil = __import__("shutil")
+        if fake_dm.exists():
+            shutil.rmtree(fake_dm, ignore_errors=True)
+
+
 def test_write_agent_context(tmp_path: Path):
     from zen.wiki.export import write_agent_context
     from zen.wiki.paths import VisualWikiPaths
 
-    wiki_root = Path.cwd() / "integrations" / "visual-wiki"
-    if not wiki_root.is_dir():
-        return
+    wiki_root = tmp_path / "wiki"
+    wiki_root.mkdir()
+    (wiki_root / "package.json").write_text("{}", encoding="utf-8")
+    (wiki_root / "resources.json").write_text("[]", encoding="utf-8")
 
     paths = VisualWikiPaths(
         root=wiki_root,
         resources_file=wiki_root / "resources.json",
         package_json=wiki_root / "package.json",
+        source="test",
     )
-    written = write_agent_context(output_dir=tmp_path, paths=paths)
+    written = write_agent_context(output_dir=tmp_path / "out", paths=paths)
     assert written["json"].is_file()
     payload = json.loads(written["json"].read_text())
     assert "resources" in payload
@@ -59,4 +88,5 @@ def test_write_agent_context(tmp_path: Path):
 if __name__ == "__main__":
     test_imports()
     test_export_shape()
+    test_locate_dev_master_monkeypatch()
     print("OK: visual wiki tests passed")

--- a/test_wiki_simple.py
+++ b/test_wiki_simple.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Simple tests for Visual Wiki integration."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, ".")
+
+
+def test_imports():
+    from zen.wiki import build_agent_export, load_resources, resolve_visual_wiki_root
+    from zen.wiki.cli import wiki
+
+    assert wiki is not None
+    root = resolve_visual_wiki_root(Path.cwd())
+    assert root.name == "visual-wiki"
+
+
+def test_export_shape():
+    from zen.wiki.export import build_agent_export, format_agent_prompt
+
+    sample = [
+        {
+            "title": "Test",
+            "description": "Desc",
+            "category": "repo",
+            "tags": ["a"],
+            "link": "https://example.com",
+        }
+    ]
+    export = build_agent_export(sample)
+    assert export["total"] == 1
+    assert export["resources"][0]["title"] == "Test"
+    prompt = format_agent_prompt(sample)
+    assert "visual wiki" in prompt
+    assert "https://example.com" in prompt
+
+
+def test_write_agent_context(tmp_path: Path):
+    from zen.wiki.export import write_agent_context
+    from zen.wiki.paths import VisualWikiPaths
+
+    wiki_root = Path.cwd() / "integrations" / "visual-wiki"
+    if not wiki_root.is_dir():
+        return
+
+    paths = VisualWikiPaths(
+        root=wiki_root,
+        resources_file=wiki_root / "resources.json",
+        package_json=wiki_root / "package.json",
+    )
+    written = write_agent_context(output_dir=tmp_path, paths=paths)
+    assert written["json"].is_file()
+    payload = json.loads(written["json"].read_text())
+    assert "resources" in payload
+
+
+if __name__ == "__main__":
+    test_imports()
+    test_export_shape()
+    print("OK: visual wiki tests passed")

--- a/zen/cli.py
+++ b/zen/cli.py
@@ -333,5 +333,9 @@ cli.add_command(receive)
 from zen.pkm.cli import pkm
 cli.add_command(pkm)
 
+# Visual Wiki knowledge garden
+from zen.wiki.cli import wiki
+cli.add_command(wiki)
+
 if __name__ == "__main__":
     cli()

--- a/zen/core/context.py
+++ b/zen/core/context.py
@@ -138,6 +138,7 @@ class ContextManager:
         self._load_genesis_docs()
         self._load_project_context()
         self._load_git_context()
+        self._load_visual_wiki_context()
     
     def _load_genesis_docs(self):
         """Load genesis documents from ai-inbox or project root."""
@@ -192,6 +193,17 @@ class ContextManager:
         except Exception as e:
             console.print(f"[yellow]Warning: Could not load project context: {e}[/yellow]")
     
+    def _load_visual_wiki_context(self):
+        """Load curated Visual Wiki exports when synced to ~/.zenOS/context."""
+        self.visual_wiki_context: Dict[str, Any] = {}
+        context_file = Path.home() / ".zenOS" / "context" / "visual-wiki.json"
+        if not context_file.is_file():
+            return
+        try:
+            self.visual_wiki_context = json.loads(context_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            self.visual_wiki_context = {}
+
     def _load_git_context(self):
         """Load git information."""
         try:
@@ -336,6 +348,7 @@ Key philosophical principles from the genesis documents:
             "genesis": self.genesis_docs,
             "project": self.project_context,
             "git": self.git_context,
+            "visual_wiki": getattr(self, "visual_wiki_context", {}),
             "cultural_references": self.CULTURAL_REFERENCES
         }
     
@@ -366,6 +379,19 @@ Key philosophical principles from the genesis documents:
             parts.append(f"\n--- Genesis Wisdom ---")
             parts.append("The system is guided by the genesis documents: System Manifest, Genesis Log, and Manuscript Draft.")
             parts.append("Core principle: Build sovereign systems, not features.")
+
+        wiki_ctx = getattr(self, "visual_wiki_context", {})
+        if wiki_ctx.get("resources"):
+            parts.append("\n--- Visual Wiki (curated resources) ---")
+            parts.append(
+                f"{wiki_ctx.get('total', len(wiki_ctx['resources']))} resources "
+                "(run `zen wiki sync` to refresh)"
+            )
+            for item in wiki_ctx["resources"][:15]:
+                parts.append(
+                    f"• {item.get('title', '')} — {item.get('description', '')} "
+                    f"[{item.get('link', '')}]"
+                )
         
         return "\n".join(parts)
 

--- a/zen/setup/unified_setup.py
+++ b/zen/setup/unified_setup.py
@@ -278,6 +278,11 @@ class UnifiedSetupManager:
         if not self._setup_workspace():
             print("  ❌ Failed to setup workspace")
             return False
+
+        # Visual Wiki (optional — requires git + node for full UI)
+        print("  🌿 Setting up Visual Wiki integration...")
+        if not self._setup_visual_wiki():
+            print("  ⚠️  Visual Wiki setup skipped or incomplete, continuing...")
         
         self.current_phase = SetupPhase.VERIFICATION
         return True
@@ -483,6 +488,48 @@ alias zen-plugins='python3 "{self.zenos_root}/zen/cli.py" plugins'
             print(f"  ❌ promptOS integration failed: {e}")
             return False
     
+    def _setup_visual_wiki(self) -> bool:
+        """Initialize Visual Wiki submodule and agent context directory."""
+        try:
+            wiki_path = self.zenos_root / "integrations" / "visual-wiki"
+            gitmodules = self.zenos_root / ".gitmodules"
+            if gitmodules.exists() and not (wiki_path / "package.json").is_file():
+                subprocess.run(
+                    [
+                        "git",
+                        "submodule",
+                        "update",
+                        "--init",
+                        "--recursive",
+                        "integrations/visual-wiki",
+                    ],
+                    cwd=str(self.zenos_root),
+                    capture_output=True,
+                    text=True,
+                )
+
+            context_dir = self.context.user_home / ".zenOS" / "context"
+            context_dir.mkdir(parents=True, exist_ok=True)
+
+            if (wiki_path / "package.json").is_file():
+                print("  ✅ Visual Wiki submodule present")
+                if self.context.node_available:
+                    subprocess.run(
+                        ["npm", "install"],
+                        cwd=str(wiki_path),
+                        capture_output=True,
+                        text=True,
+                    )
+                    print("  ✅ Visual Wiki npm dependencies installed")
+                else:
+                    print("  ⚠️  Node.js not available — run `zen wiki setup` later")
+            else:
+                print("  ⚠️  Visual Wiki submodule missing — run `zen wiki setup`")
+            return True
+        except Exception as e:
+            print(f"  ⚠️  Visual Wiki setup error: {e}")
+            return False
+
     def _setup_workspace(self) -> bool:
         """Setup workspace directories"""
         try:
@@ -497,7 +544,8 @@ alias zen-plugins='python3 "{self.zenos_root}/zen/cli.py" plugins'
                 "inbox/processed",
                 "inbox/tools",
                 "inbox/context",
-                "inbox/ideas"
+                "inbox/ideas",
+                "integrations",
             ]
             
             for dir_path in workspace_dirs:

--- a/zen/setup/unified_setup.py
+++ b/zen/setup/unified_setup.py
@@ -489,34 +489,20 @@ alias zen-plugins='python3 "{self.zenos_root}/zen/cli.py" plugins'
             return False
     
     def _setup_visual_wiki(self) -> bool:
-        """Initialize Visual Wiki submodule and agent context directory."""
+        """Ensure agent context dir exists; Visual Wiki lives outside zenOS."""
         try:
-            wiki_path = self.zenos_root / "integrations" / "visual-wiki"
-            gitmodules = self.zenos_root / ".gitmodules"
-            if gitmodules.exists() and not (wiki_path / "package.json").is_file():
-                subprocess.run(
-                    [
-                        "git",
-                        "submodule",
-                        "update",
-                        "--init",
-                        "--recursive",
-                        "integrations/visual-wiki",
-                    ],
-                    cwd=str(self.zenos_root),
-                    capture_output=True,
-                    text=True,
-                )
-
             context_dir = self.context.user_home / ".zenOS" / "context"
             context_dir.mkdir(parents=True, exist_ok=True)
 
-            if (wiki_path / "package.json").is_file():
-                print("  ✅ Visual Wiki submodule present")
+            from zen.wiki.paths import locate_visual_wiki
+
+            found, source = locate_visual_wiki(self.zenos_root)
+            if found and (found / "package.json").is_file():
+                print(f"  ✅ Visual Wiki found ({source})")
                 if self.context.node_available:
                     subprocess.run(
                         ["npm", "install"],
-                        cwd=str(wiki_path),
+                        cwd=str(found),
                         capture_output=True,
                         text=True,
                     )
@@ -524,7 +510,10 @@ alias zen-plugins='python3 "{self.zenos_root}/zen/cli.py" plugins'
                 else:
                     print("  ⚠️  Node.js not available — run `zen wiki setup` later")
             else:
-                print("  ⚠️  Visual Wiki submodule missing — run `zen wiki setup`")
+                print(
+                    "  ℹ️  Visual Wiki is a separate repo (dev-master submodule: "
+                    "dex/09-repos/visual-wiki). Run `zen wiki setup` to clone locally."
+                )
             return True
         except Exception as e:
             print(f"  ⚠️  Visual Wiki setup error: {e}")

--- a/zen/wiki/__init__.py
+++ b/zen/wiki/__init__.py
@@ -1,12 +1,19 @@
 """Visual Wiki integration for zenOS — curated knowledge garden for agents."""
 
 from .export import build_agent_export, format_agent_prompt, load_resources
-from .paths import VisualWikiPaths, resolve_visual_wiki_root
+from .paths import (
+    VisualWikiPaths,
+    dev_master_root,
+    locate_visual_wiki,
+    resolve_visual_wiki_root,
+)
 from .pipe import default_base_url, fetch_handshake, pipe_url
 
 __all__ = [
     "VisualWikiPaths",
     "resolve_visual_wiki_root",
+    "locate_visual_wiki",
+    "dev_master_root",
     "load_resources",
     "build_agent_export",
     "format_agent_prompt",

--- a/zen/wiki/__init__.py
+++ b/zen/wiki/__init__.py
@@ -1,0 +1,16 @@
+"""Visual Wiki integration for zenOS — curated knowledge garden for agents."""
+
+from .export import build_agent_export, format_agent_prompt, load_resources
+from .paths import VisualWikiPaths, resolve_visual_wiki_root
+from .pipe import default_base_url, fetch_handshake, pipe_url
+
+__all__ = [
+    "VisualWikiPaths",
+    "resolve_visual_wiki_root",
+    "load_resources",
+    "build_agent_export",
+    "format_agent_prompt",
+    "default_base_url",
+    "fetch_handshake",
+    "pipe_url",
+]

--- a/zen/wiki/cli.py
+++ b/zen/wiki/cli.py
@@ -22,8 +22,12 @@ from .export import (
     write_agent_context,
 )
 from .paths import (
+    DEFAULT_USER_INSTALL,
     VISUAL_WIKI_REPO,
     VisualWikiPaths,
+    dev_master_root,
+    dev_master_wiki_candidates,
+    locate_visual_wiki,
     visual_wiki_paths,
 )
 from .pipe import default_base_url, fetch_handshake, pipe_url
@@ -35,7 +39,8 @@ def _require_checkout(paths: VisualWikiPaths) -> None:
     if paths.is_checkout:
         return
     console.print(
-        "[red]Visual Wiki is not installed.[/red] Run [cyan]zen wiki setup[/cyan] first."
+        "[red]Visual Wiki is not installed.[/red] Run [cyan]zen wiki setup[/cyan] "
+        "(clone) or point [cyan]ZEN_VISUAL_WIKI_PATH[/cyan] at a dev-master submodule checkout."
     )
     sys.exit(1)
 
@@ -58,21 +63,30 @@ def wiki():
 
 @wiki.command("setup")
 @click.option(
-    "--clone",
+    "--into",
+    "install_dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help=f"Clone target (default: {DEFAULT_USER_INSTALL})",
+)
+@click.option(
+    "--skip-clone",
     is_flag=True,
-    help="Clone into ~/.zenOS/visual-wiki instead of using the git submodule",
+    help="Only npm install when a checkout is already resolved",
 )
 @click.option("--skip-npm", is_flag=True, help="Skip npm install")
-def setup(clone: bool, skip_npm: bool):
-    """Initialize Visual Wiki (submodule or clone) and install Node dependencies."""
-    zenos_root = Path.cwd()
-    if (zenos_root / "zen" / "cli.py").is_file():
-        wiki_root = zenos_root / "integrations" / "visual-wiki"
-    else:
-        wiki_root = resolve_visual_wiki_root()
+def setup(install_dir: Optional[str], skip_clone: bool, skip_npm: bool):
+    """
+    Clone the standalone visual-wiki repo and install Node dependencies.
 
-    if clone:
-        wiki_root = Path.home() / ".zenOS" / "visual-wiki"
+    zenOS does not vendor visual-wiki; dev-master tracks it as a submodule at
+    dex/09-repos/visual-wiki when that wiring lands. Set ZEN_VISUAL_WIKI_PATH or
+    DEV_MASTER_ROOT to use an existing checkout instead of cloning.
+    """
+    found, source = locate_visual_wiki()
+    wiki_root: Optional[Path] = found
+
+    if not wiki_root and not skip_clone:
+        wiki_root = Path(install_dir).expanduser() if install_dir else DEFAULT_USER_INSTALL
         wiki_root.parent.mkdir(parents=True, exist_ok=True)
         if not (wiki_root / "package.json").is_file():
             console.print(f"Cloning Visual Wiki to {wiki_root}...")
@@ -84,29 +98,23 @@ def setup(clone: bool, skip_npm: bool):
             if result.returncode != 0:
                 console.print(f"[red]Clone failed:[/red] {result.stderr}")
                 sys.exit(1)
-        os.environ["ZEN_VISUAL_WIKI_PATH"] = str(wiki_root)
+        source = str(wiki_root)
+        console.print(
+            "[dim]Tip: export ZEN_VISUAL_WIKI_PATH="
+            f'"{wiki_root}"[/dim] [dim]to pin this checkout.[/dim]'
+        )
+    elif wiki_root:
+        console.print(f"Using existing checkout ({source}): {wiki_root}")
     else:
-        wiki_root = zenos_root / "integrations" / "visual-wiki"
-        if not (wiki_root / "package.json").is_file():
-            console.print("Initializing git submodule...")
-            result = subprocess.run(
-                [
-                    "git",
-                    "submodule",
-                    "update",
-                    "--init",
-                    "--recursive",
-                    "integrations/visual-wiki",
-                ],
-                cwd=str(zenos_root),
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                console.print(f"[red]Submodule init failed:[/red] {result.stderr}")
-                sys.exit(1)
+        console.print("[red]No checkout found and --skip-clone was set.[/red]")
+        sys.exit(1)
 
-    paths = visual_wiki_paths(zenos_root)
+    paths = VisualWikiPaths(
+        root=wiki_root,
+        resources_file=wiki_root / "resources.json",
+        package_json=wiki_root / "package.json",
+        source=source or "setup",
+    )
     if not paths.is_checkout:
         console.print("[red]Visual Wiki checkout not found after setup.[/red]")
         sys.exit(1)
@@ -133,17 +141,35 @@ def show_path():
 def status():
     """Show Visual Wiki install and resource summary."""
     paths = visual_wiki_paths()
-    resources = load_resources(paths)
+    resources = load_resources(paths) if paths.is_checkout else []
 
     table = Table(title="Visual Wiki")
     table.add_column("Key", style="cyan")
     table.add_column("Value")
     table.add_row("Root", str(paths.root))
+    table.add_row("Source", paths.source)
     table.add_row("Checkout", "yes" if paths.is_checkout else "no")
     table.add_row("resources.json", "yes" if paths.resources_file.is_file() else "no")
     table.add_row("Resources", str(len(resources)))
     table.add_row("npm", shutil.which("npm") or "not found")
+
+    dm = dev_master_root()
+    table.add_row("dev-master", str(dm) if dm else "not found")
+    for candidate in dev_master_wiki_candidates():
+        try:
+            label = candidate.relative_to(dm) if dm else candidate
+        except ValueError:
+            label = candidate
+        present = "yes" if (candidate / "package.json").is_file() else "no"
+        table.add_row(f"  {label}", present)
+
     console.print(table)
+    if not paths.is_checkout:
+        console.print(
+            "\n[dim]visual-wiki is a separate repo. Clone with[/dim] "
+            "[cyan]zen wiki setup[/cyan][dim], use dev-master's submodule when available, "
+            "or set ZEN_VISUAL_WIKI_PATH.[/dim]"
+        )
 
 
 @wiki.command("dev")
@@ -206,8 +232,10 @@ def prompt_cmd():
 )
 def sync(output_dir: Optional[str]):
     """Sync exports to ~/.zenOS/context for agent context hydration."""
+    paths = visual_wiki_paths()
+    _require_checkout(paths)
     out = Path(output_dir) if output_dir else None
-    written = write_agent_context(output_dir=out)
+    written = write_agent_context(output_dir=out, paths=paths)
     console.print("[green]✓[/green] Agent context updated:")
     for label, path in written.items():
         console.print(f"  {label}: {path}")

--- a/zen/wiki/cli.py
+++ b/zen/wiki/cli.py
@@ -1,0 +1,264 @@
+"""CLI for Visual Wiki — knowledge garden integration."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from .export import (
+    build_agent_export,
+    format_agent_prompt,
+    load_resources,
+    write_agent_context,
+)
+from .paths import (
+    VISUAL_WIKI_REPO,
+    VisualWikiPaths,
+    visual_wiki_paths,
+)
+from .pipe import default_base_url, fetch_handshake, pipe_url
+
+console = Console()
+
+
+def _require_checkout(paths: VisualWikiPaths) -> None:
+    if paths.is_checkout:
+        return
+    console.print(
+        "[red]Visual Wiki is not installed.[/red] Run [cyan]zen wiki setup[/cyan] first."
+    )
+    sys.exit(1)
+
+
+def _run_npm(args: list[str], cwd: Path, env: Optional[dict] = None) -> int:
+    npm = shutil.which("npm")
+    if not npm:
+        console.print("[red]npm not found.[/red] Install Node.js to run Visual Wiki.")
+        return 1
+    merged = {**os.environ, **(env or {})}
+    result = subprocess.run([npm, *args], cwd=str(cwd), env=merged)
+    return result.returncode
+
+
+@click.group()
+def wiki():
+    """🌿 Visual Wiki — curated knowledge garden for AI agents."""
+    pass
+
+
+@wiki.command("setup")
+@click.option(
+    "--clone",
+    is_flag=True,
+    help="Clone into ~/.zenOS/visual-wiki instead of using the git submodule",
+)
+@click.option("--skip-npm", is_flag=True, help="Skip npm install")
+def setup(clone: bool, skip_npm: bool):
+    """Initialize Visual Wiki (submodule or clone) and install Node dependencies."""
+    zenos_root = Path.cwd()
+    if (zenos_root / "zen" / "cli.py").is_file():
+        wiki_root = zenos_root / "integrations" / "visual-wiki"
+    else:
+        wiki_root = resolve_visual_wiki_root()
+
+    if clone:
+        wiki_root = Path.home() / ".zenOS" / "visual-wiki"
+        wiki_root.parent.mkdir(parents=True, exist_ok=True)
+        if not (wiki_root / "package.json").is_file():
+            console.print(f"Cloning Visual Wiki to {wiki_root}...")
+            result = subprocess.run(
+                ["git", "clone", "--depth", "1", VISUAL_WIKI_REPO, str(wiki_root)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                console.print(f"[red]Clone failed:[/red] {result.stderr}")
+                sys.exit(1)
+        os.environ["ZEN_VISUAL_WIKI_PATH"] = str(wiki_root)
+    else:
+        wiki_root = zenos_root / "integrations" / "visual-wiki"
+        if not (wiki_root / "package.json").is_file():
+            console.print("Initializing git submodule...")
+            result = subprocess.run(
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                    "integrations/visual-wiki",
+                ],
+                cwd=str(zenos_root),
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                console.print(f"[red]Submodule init failed:[/red] {result.stderr}")
+                sys.exit(1)
+
+    paths = visual_wiki_paths(zenos_root)
+    if not paths.is_checkout:
+        console.print("[red]Visual Wiki checkout not found after setup.[/red]")
+        sys.exit(1)
+
+    if skip_npm:
+        console.print("[green]✓[/green] Visual Wiki ready (skipped npm install).")
+        return
+
+    console.print("Installing npm dependencies...")
+    code = _run_npm(["install"], paths.root)
+    if code != 0:
+        sys.exit(code)
+    console.print(f"[green]✓[/green] Visual Wiki ready at {paths.root}")
+
+
+@wiki.command("path")
+def show_path():
+    """Print the resolved Visual Wiki root directory."""
+    paths = visual_wiki_paths()
+    console.print(str(paths.root))
+
+
+@wiki.command("status")
+def status():
+    """Show Visual Wiki install and resource summary."""
+    paths = visual_wiki_paths()
+    resources = load_resources(paths)
+
+    table = Table(title="Visual Wiki")
+    table.add_column("Key", style="cyan")
+    table.add_column("Value")
+    table.add_row("Root", str(paths.root))
+    table.add_row("Checkout", "yes" if paths.is_checkout else "no")
+    table.add_row("resources.json", "yes" if paths.resources_file.is_file() else "no")
+    table.add_row("Resources", str(len(resources)))
+    table.add_row("npm", shutil.which("npm") or "not found")
+    console.print(table)
+
+
+@wiki.command("dev")
+@click.option("--port", "-p", default=3000, show_default=True, type=int)
+def dev(port: int):
+    """Start the Visual Wiki Next.js dev server."""
+    paths = visual_wiki_paths()
+    _require_checkout(paths)
+    console.print(
+        Panel.fit(
+            f"[bold cyan]🌿 Visual Wiki[/bold cyan]\nhttp://localhost:{port}",
+            border_style="cyan",
+        )
+    )
+    code = _run_npm(["run", "dev"], paths.root, env={"PORT": str(port)})
+    sys.exit(code)
+
+
+@wiki.command("build")
+def build():
+    """Run a production build of Visual Wiki."""
+    paths = visual_wiki_paths()
+    _require_checkout(paths)
+    code = _run_npm(["run", "build"], paths.root)
+    sys.exit(code)
+
+
+@wiki.command("export")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Write JSON export to this file (stdout if omitted)",
+)
+def export_cmd(output: Optional[str]):
+    """Export curated resources as agent-ready JSON."""
+    resources = load_resources()
+    payload = build_agent_export(resources)
+    text = json.dumps(payload, indent=2)
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        console.print(f"[green]✓[/green] Wrote {output}")
+    else:
+        console.print(text)
+
+
+@wiki.command("prompt")
+def prompt_cmd():
+    """Print the agent-ready text summary of curated resources."""
+    resources = load_resources()
+    console.print(format_agent_prompt(resources))
+
+
+@wiki.command("sync")
+@click.option(
+    "--output-dir",
+    "-d",
+    type=click.Path(file_okay=False, writable=True),
+    help="Directory for visual-wiki.json and visual-wiki-prompt.txt",
+)
+def sync(output_dir: Optional[str]):
+    """Sync exports to ~/.zenOS/context for agent context hydration."""
+    out = Path(output_dir) if output_dir else None
+    written = write_agent_context(output_dir=out)
+    console.print("[green]✓[/green] Agent context updated:")
+    for label, path in written.items():
+        console.print(f"  {label}: {path}")
+
+
+@wiki.command("pull")
+@click.option(
+    "--base-url",
+    default=None,
+    help="Visual Wiki origin (default: ZEN_VISUAL_WIKI_URL or http://localhost:3000)",
+)
+def pull(base_url: Optional[str]):
+    """Fetch /api/pipe handshake from a running Visual Wiki instance."""
+    try:
+        data = fetch_handshake(base_url)
+    except Exception as exc:
+        console.print(
+            f"[red]Pull failed:[/red] {exc}\n"
+            "Start the app with [cyan]zen wiki dev[/cyan] first."
+        )
+        sys.exit(1)
+    console.print(
+        Panel.fit(
+            f"status={data.get('status')} total={data.get('total')} "
+            f"fingerprint={str(data.get('fingerprint', ''))[:48]}…",
+            title="Visual Wiki handshake",
+            border_style="cyan",
+        )
+    )
+
+
+@wiki.command("pipe")
+@click.argument("url")
+@click.option(
+    "--base-url",
+    default=None,
+    help="Visual Wiki origin (default: ZEN_VISUAL_WIKI_URL or http://localhost:3000)",
+)
+@click.option("--type", "resource_type", default=None, help="Pipe type hint (e.g. web)")
+def pipe_cmd(url: str, base_url: Optional[str], resource_type: Optional[str]):
+    """Ingest a URL into the garden via /api/pipe (dev server must be running)."""
+    try:
+        result = pipe_url(url, base_url=base_url, resource_type=resource_type)
+    except Exception as exc:
+        console.print(f"[red]Pipe failed:[/red] {exc}")
+        sys.exit(1)
+    method = result.get("method", "unknown")
+    resource = result.get("resource", {})
+    title = resource.get("title", url)
+    console.print(f"[green]✓[/green] Ingested via {method}: {title}")
+    console.print(
+        f"[dim]Then run[/dim] [cyan]zen wiki sync[/cyan] "
+        f"[dim]to refresh agent context ({default_base_url()})[/dim]"
+    )

--- a/zen/wiki/export.py
+++ b/zen/wiki/export.py
@@ -1,0 +1,81 @@
+"""Export Visual Wiki resources for AI agent context."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .paths import VisualWikiPaths, visual_wiki_paths
+
+
+def load_resources(paths: Optional[VisualWikiPaths] = None) -> List[Dict[str, Any]]:
+    """Load curated resources from ``resources.json`` if present."""
+    paths = paths or visual_wiki_paths()
+    data_file = paths.resources_file
+    if not data_file.is_file():
+        return []
+    try:
+        payload = json.loads(data_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    if isinstance(payload, list):
+        return [r for r in payload if isinstance(r, dict)]
+    return []
+
+
+def build_agent_export(resources: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the same JSON shape as the web UI \"Export for AI\" action."""
+    slim = [
+        {
+            "title": r.get("title", ""),
+            "description": r.get("description", ""),
+            "category": r.get("category", ""),
+            "tags": r.get("tags", []),
+            "link": r.get("link", ""),
+        }
+        for r in resources
+    ]
+    return {
+        "exportedAt": datetime.now(timezone.utc).isoformat(),
+        "total": len(slim),
+        "resources": slim,
+    }
+
+
+def format_agent_prompt(resources: List[Dict[str, Any]]) -> str:
+    """Format resources as a prompt-ready summary (matches the web UI)."""
+    if not resources:
+        return "Here is my curated visual wiki (0 resources):\n\n"
+    lines = [
+        f"• {r.get('title', 'Untitled')} — {r.get('description', '')} [{r.get('link', '')}]"
+        for r in resources
+    ]
+    return (
+        f"Here is my curated visual wiki ({len(resources)} resources):\n\n"
+        + "\n".join(lines)
+    )
+
+
+def write_agent_context(
+    output_dir: Optional[Path] = None,
+    paths: Optional[VisualWikiPaths] = None,
+) -> Dict[str, Path]:
+    """Write JSON export and prompt text under ``~/.zenOS/context`` by default."""
+    from .paths import default_agent_context_dir
+
+    paths = paths or visual_wiki_paths()
+    resources = load_resources(paths)
+    export = build_agent_export(resources)
+    prompt = format_agent_prompt(resources)
+
+    out = output_dir or default_agent_context_dir()
+    out.mkdir(parents=True, exist_ok=True)
+
+    json_path = out / "visual-wiki.json"
+    prompt_path = out / "visual-wiki-prompt.txt"
+    json_path.write_text(json.dumps(export, indent=2), encoding="utf-8")
+    prompt_path.write_text(prompt, encoding="utf-8")
+
+    return {"json": json_path, "prompt": prompt_path}

--- a/zen/wiki/paths.py
+++ b/zen/wiki/paths.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Tuple
 
 VISUAL_WIKI_REPO = "https://github.com/k-dot-greyz/visual-wiki.git"
-DEFAULT_SUBMODULE_REL = Path("integrations") / "visual-wiki"
+DEFAULT_USER_INSTALL = Path.home() / ".zenOS" / "visual-wiki"
+
+# Canonical layout in dev-master (submodule target per visual-wiki EXTRACT docs).
+DEV_MASTER_WIKI_CANDIDATES = (
+    Path("dex") / "09-repos" / "visual-wiki",
+    Path("projects") / "visual-wiki",
+)
+
+# Legacy zenOS path (removed from repo; still honored if present locally).
+LEGACY_ZENOS_INTEGRATION = Path("integrations") / "visual-wiki"
 
 
 @dataclass(frozen=True)
@@ -18,39 +27,100 @@ class VisualWikiPaths:
     root: Path
     resources_file: Path
     package_json: Path
+    source: str = "unknown"
 
     @property
     def is_checkout(self) -> bool:
         return self.package_json.is_file()
 
 
-def resolve_visual_wiki_root(zenos_root: Optional[Path] = None) -> Path:
-    """
-    Resolve the Visual Wiki project root.
+def dev_master_root() -> Optional[Path]:
+    """Locate a dev-master superproject checkout."""
+    env_path = os.environ.get("DEV_MASTER_ROOT")
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if candidate.is_dir():
+            return candidate.resolve()
 
-    Priority: ``ZEN_VISUAL_WIKI_PATH`` → ``~/.zenOS/visual-wiki`` →
-    ``<zenos_root>/integrations/visual-wiki``.
+    for candidate in (
+        Path.home() / "Code" / "dev-master",
+        Path.home() / "dev-master",
+    ):
+        if _looks_like_dev_master(candidate):
+            return candidate.resolve()
+    return None
+
+
+def _looks_like_dev_master(path: Path) -> bool:
+    return (path / "dex").is_dir() or (path / "AGENTS.md").is_file()
+
+
+def _is_wiki_checkout(path: Path) -> bool:
+    return (path / "package.json").is_file()
+
+
+def locate_visual_wiki(zenos_root: Optional[Path] = None) -> Tuple[Optional[Path], str]:
+    """
+    Find an existing Visual Wiki checkout.
+
+    Returns ``(path, source_label)`` or ``(None, reason)`` when nothing is installed.
     """
     env_path = os.environ.get("ZEN_VISUAL_WIKI_PATH")
     if env_path:
-        return Path(env_path).expanduser().resolve()
+        root = Path(env_path).expanduser().resolve()
+        if _is_wiki_checkout(root):
+            return root, "ZEN_VISUAL_WIKI_PATH"
+        return None, "ZEN_VISUAL_WIKI_PATH is set but not a Visual Wiki checkout"
 
-    user_wiki = Path.home() / ".zenOS" / "visual-wiki"
-    if user_wiki.is_dir() and (user_wiki / "package.json").is_file():
-        return user_wiki.resolve()
+    if _is_wiki_checkout(DEFAULT_USER_INSTALL):
+        return DEFAULT_USER_INSTALL.resolve(), "~/.zenOS/visual-wiki"
+
+    dm = dev_master_root()
+    if dm:
+        for rel in DEV_MASTER_WIKI_CANDIDATES:
+            candidate = (dm / rel).resolve()
+            if _is_wiki_checkout(candidate):
+                return candidate, f"dev-master ({rel.as_posix()})"
 
     root = zenos_root or _find_zenos_root()
-    return (root / DEFAULT_SUBMODULE_REL).resolve()
+    legacy = (root / LEGACY_ZENOS_INTEGRATION).resolve()
+    if _is_wiki_checkout(legacy):
+        return legacy, "legacy integrations/visual-wiki (local only)"
+
+    return None, "not installed"
+
+
+def resolve_visual_wiki_root(zenos_root: Optional[Path] = None) -> Path:
+    """
+    Resolved Visual Wiki root for display and defaults.
+
+    When no checkout exists, returns the recommended install path
+    (``~/.zenOS/visual-wiki``).
+    """
+    found, _ = locate_visual_wiki(zenos_root)
+    if found:
+        return found
+    return DEFAULT_USER_INSTALL.resolve()
 
 
 def visual_wiki_paths(zenos_root: Optional[Path] = None) -> VisualWikiPaths:
     """Return common paths for the resolved Visual Wiki root."""
-    wiki_root = resolve_visual_wiki_root(zenos_root)
+    found, source = locate_visual_wiki(zenos_root)
+    wiki_root = found if found else DEFAULT_USER_INSTALL.resolve()
     return VisualWikiPaths(
         root=wiki_root,
         resources_file=wiki_root / "resources.json",
         package_json=wiki_root / "package.json",
+        source=source,
     )
+
+
+def dev_master_wiki_candidates() -> List[Path]:
+    """Paths to check under dev-master (for status / docs)."""
+    dm = dev_master_root()
+    if not dm:
+        return []
+    return [(dm / rel).resolve() for rel in DEV_MASTER_WIKI_CANDIDATES]
 
 
 def _find_zenos_root() -> Path:

--- a/zen/wiki/paths.py
+++ b/zen/wiki/paths.py
@@ -1,0 +1,66 @@
+"""Resolve Visual Wiki install locations."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+VISUAL_WIKI_REPO = "https://github.com/k-dot-greyz/visual-wiki.git"
+DEFAULT_SUBMODULE_REL = Path("integrations") / "visual-wiki"
+
+
+@dataclass(frozen=True)
+class VisualWikiPaths:
+    """Resolved paths for the Visual Wiki Next.js app."""
+
+    root: Path
+    resources_file: Path
+    package_json: Path
+
+    @property
+    def is_checkout(self) -> bool:
+        return self.package_json.is_file()
+
+
+def resolve_visual_wiki_root(zenos_root: Optional[Path] = None) -> Path:
+    """
+    Resolve the Visual Wiki project root.
+
+    Priority: ``ZEN_VISUAL_WIKI_PATH`` → ``~/.zenOS/visual-wiki`` →
+    ``<zenos_root>/integrations/visual-wiki``.
+    """
+    env_path = os.environ.get("ZEN_VISUAL_WIKI_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    user_wiki = Path.home() / ".zenOS" / "visual-wiki"
+    if user_wiki.is_dir() and (user_wiki / "package.json").is_file():
+        return user_wiki.resolve()
+
+    root = zenos_root or _find_zenos_root()
+    return (root / DEFAULT_SUBMODULE_REL).resolve()
+
+
+def visual_wiki_paths(zenos_root: Optional[Path] = None) -> VisualWikiPaths:
+    """Return common paths for the resolved Visual Wiki root."""
+    wiki_root = resolve_visual_wiki_root(zenos_root)
+    return VisualWikiPaths(
+        root=wiki_root,
+        resources_file=wiki_root / "resources.json",
+        package_json=wiki_root / "package.json",
+    )
+
+
+def _find_zenos_root() -> Path:
+    """Walk parents from cwd to find a zenOS checkout."""
+    cwd = Path.cwd().resolve()
+    for candidate in [cwd, *cwd.parents]:
+        if (candidate / "zen" / "cli.py").is_file():
+            return candidate
+    return cwd
+
+
+def default_agent_context_dir() -> Path:
+    return Path.home() / ".zenOS" / "context"

--- a/zen/wiki/pipe.py
+++ b/zen/wiki/pipe.py
@@ -1,0 +1,50 @@
+"""HTTP client for Visual Wiki open-piping (/api/pipe)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+
+def default_base_url() -> str:
+    return os.environ.get("ZEN_VISUAL_WIKI_URL", "http://localhost:3000").rstrip("/")
+
+
+def fetch_handshake(base_url: Optional[str] = None) -> Dict[str, Any]:
+    """GET /api/pipe — schema handshake and resource index."""
+    base = (base_url or default_base_url()).rstrip("/")
+    with urllib.request.urlopen(f"{base}/api/pipe", timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def pipe_url(
+    url: str,
+    *,
+    base_url: Optional[str] = None,
+    resource_type: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """POST /api/pipe — ingest a URL or raw resource into the garden."""
+    base = (base_url or default_base_url()).rstrip("/")
+    body: Dict[str, Any] = {"url": url}
+    if resource_type:
+        body["type"] = resource_type
+    if payload:
+        body["payload"] = payload
+
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base}/api/pipe",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Pipe failed ({exc.code}): {detail}") from exc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates the standalone [visual-wiki](https://github.com/k-dot-greyz/visual-wiki) repo with zenOS **without vendoring it in this tree**. Submodule ownership belongs to **dev-master** (`dex/09-repos/visual-wiki` per upstream docs / pending PRs there).

- **`zen wiki` CLI**: `setup` (clone to `~/.zenOS/visual-wiki` by default), `dev`, `build`, `export`, `prompt`, `sync`, `pull`, `pipe`, `status`, `path`
- **Discovery order**: `ZEN_VISUAL_WIKI_PATH` → `~/.zenOS/visual-wiki` → dev-master (`DEV_MASTER_ROOT` or `~/Code/dev-master`) at `dex/09-repos/visual-wiki` or `projects/visual-wiki` → legacy local `integrations/visual-wiki` if someone still has it
- **Agent context**: `zen wiki sync` → `~/.zenOS/context/`; `ContextManager` includes synced resources in prompts
- **`zen setup`**: creates context dir and npm-installs when a checkout is already found; otherwise points you at `zen wiki setup`

## Test plan

- [x] `.venv/bin/python test_wiki_simple.py` (includes dev-master path discovery)
- [x] Submodule removed from zenOS; no `.gitmodules`

## Usage

```bash
# Standalone clone (typical for zenOS-only checkout)
zen wiki setup

# Or point at dev-master once submodule PR lands
export DEV_MASTER_ROOT=~/Code/dev-master
zen wiki status

zen wiki dev
zen wiki sync
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d7269e-4128-4e4a-ba65-57ff64ef216c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d7269e-4128-4e4a-ba65-57ff64ef216c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

