### PR TITLE
feat(harness): VITRINE as default testing harness reference

### DIFF
--- a/.github/workflows/zenos-ci.yml
+++ b/.github/workflows/zenos-ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m zen.testing.hydrate hydrate --profile ci/headless
           pip install pytest pytest-cov
       
       - name: Run tests with pytest
@@ -153,11 +153,40 @@ jobs:
           fi
         continue-on-error: true
 
+  # Testing harness — negotiation purity + token discipline (TESTING.md §7)
+  harness-validate:
+    name: Harness Validate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install minimal deps for harness module
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Negotiation must be deterministic
+        run: |
+          python -m zen.testing.hydrate negotiate --profile ci/headless --json > /tmp/p1.json
+          python -m zen.testing.hydrate negotiate --profile ci/headless --json > /tmp/p2.json
+          diff /tmp/p1.json /tmp/p2.json
+
+      - name: Harness property tests
+        run: pytest tests/test_harness_hydrate.py -v
+
   # Summary job - reports overall status
   ci-success:
     name: CI Status Check
     runs-on: ubuntu-22.04
-    needs: [lint, test, security, shell-check, docs]
+    needs: [lint, test, security, shell-check, docs, harness-validate]
     if: always()
     steps:
       - name: Check all jobs status
@@ -167,9 +196,11 @@ jobs:
           echo "Security: ${{ needs.security.result }}"
           echo "Shell Check: ${{ needs.shell-check.result }}"
           echo "Docs: ${{ needs.docs.result }}"
+          echo "Harness: ${{ needs.harness-validate.result }}"
           
           if [ "${{ needs.lint.result }}" != "success" ] || \
-             [ "${{ needs.test.result }}" != "success" ]; then
+             [ "${{ needs.test.result }}" != "success" ] || \
+             [ "${{ needs.harness-validate.result }}" != "success" ]; then
             echo "::warning::Some checks failed or were skipped"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # zenOS .gitignore
 # Project types detected: python, windows, ide, logs
 
+# Harness evidence journal (generated at hydrate)
+ledger/*.jsonl
+ledger/hydrate.journal.jsonl
+!ledger/.gitkeep
+
 # PYTHON
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -202,10 +202,33 @@ zen dex sync
 
 ---
 
+## 🧪 Testing & Harness
+
+zenOS uses the **VITRINE** doc set as its default testing harness reference (`docs/testing-harness/`). Runtime VITRINE is design-only; this repo ships **tokens**, **stack lock**, and **hydrate** for programmatic startup.
+
+```bash
+# House rules + integration map
+cat docs/testing-harness/HOUSE_RULES.md
+
+# DECLARE → NEGOTIATE → HYDRATE (journal at ledger/hydrate.journal.jsonl)
+python -m zen.testing.hydrate negotiate --profile ci/headless --json
+python -m zen.testing.hydrate hydrate --profile ci/headless --dry-run
+
+# Unit tests + harness properties
+pytest tests/ -v
+python test_runner.py   # legacy smoke suite
+```
+
+Literals for budgets and timeouts: `tokens/testing-harness.toml`. Provider bindings: `zenos.stack.lock`.
+
+---
+
 ## 📖 Documentation
 
 - **[Quick Start Guide](docs/guides/QUICKSTART.md)** - Get started in minutes
 - **[AI Instructions](docs/AI_INSTRUCTIONS.md)** - For AI agents
+- **[Testing Harness Reference](docs/testing-harness/README.md)** - VITRINE default harness (design + zenOS bindings)
+- **[Harness House Rules](docs/testing-harness/HOUSE_RULES.md)** - I2 tokens, hydrate handshake, CI gates
 - **[Integration Blueprint](docs/planning/AI_INTEGRATION_BLUEPRINT.md)** - Architecture deep dive
 - **[Setup Guides](docs/guides/)** - Platform-specific instructions
 - **[Genesis Log (archive)](docs/archive/zenOS-genesis-log.md)** - The origin story (historical)

--- a/dex/procedures.yaml
+++ b/dex/procedures.yaml
@@ -238,6 +238,32 @@ procedures:
     usage_count: 156
     tools: ["zen_repo_manager.py status", "repositories-mcp get_repository_status"]
 
+  - id: "zen.test.harness"
+    name: "Testing Harness (VITRINE reference)"
+    type: "validation"
+    tier: "uncommon"
+    stats:
+      complexity: 45
+      efficiency: 90
+      reliability: 96
+    requirements:
+      - "tokens/testing-harness.toml"
+      - "zenos.stack.lock"
+      - "policy/testing-harness.toml"
+    description: "DECLARE/NEGOTIATE/HYDRATE startup per docs/testing-harness/PROVISIONING.md"
+    discovered_by: "ai:cursor-agent"
+    discovery_date: "2026-08-12"
+    evolution_path:
+      next: "zen.test.harness.conformance"
+    usage_count: 0
+    docs:
+      - "docs/testing-harness/HOUSE_RULES.md"
+      - "docs/testing-harness/ZENOS_INTEGRATION.md"
+    steps:
+      - "zen.test.harness.status"
+      - "zen.test.harness.negotiate"
+      - "zen.test.harness.hydrate"
+
 # Procedure Combinations (Combos)
 combos:
   - name: "Full Stack Refactor"

--- a/docs/AI_INSTRUCTIONS.md
+++ b/docs/AI_INSTRUCTIONS.md
@@ -82,6 +82,29 @@ procedure:
     - return_response
 ```
 
+### Step 7: Testing Harness (Default Reference)
+zenOS adopts the **VITRINE** testing harness as its default reference (design-first). House rules and integration:
+
+```bash
+# Read first (agents)
+cat docs/testing-harness/HOUSE_RULES.md
+cat docs/testing-harness/ZENOS_INTEGRATION.md
+
+# Programmatic startup — DECLARE → NEGOTIATE → HYDRATE (no silent pip)
+python -m zen.testing.hydrate status --json
+python -m zen.testing.hydrate negotiate --profile ci/headless --json
+python -m zen.testing.hydrate hydrate --profile ci/headless --dry-run
+
+# Harness property tests
+pytest tests/test_harness_hydrate.py -v
+```
+
+**Token discipline (I2):** literals for CI budgets, timeouts, and perf gates live in `tokens/testing-harness.toml`. Package versions live in `zenos.stack.lock` only. Do not inline.
+
+**One mutation path (I7):** dependency hydration flows through `zen.testing.hydrate` with journal at `ledger/hydrate.journal.jsonl` — not ad-hoc `pip install` in automation.
+
+Full doc set: `docs/testing-harness/` (VISION, SPINE, TESTING, PROVISIONING, DECISIONS).
+
 ## For Advanced AI Agents
 
 ### Registering Your Identity
@@ -165,6 +188,7 @@ If you encounter issues:
 - **Technical Issues**: Check `/README.md` for setup
 - **Procedure Questions**: Consult `/procedures/manifest.yaml`
 - **Model Selection**: Reference `/dex/models.yaml`
+- **Testing Harness**: Read `/docs/testing-harness/HOUSE_RULES.md`
 
 ## Your First Mission
 

--- a/docs/testing-harness/ARCHITECTURE.md
+++ b/docs/testing-harness/ARCHITECTURE.md
@@ -1,0 +1,239 @@
+# VITRINE — ARCHITECTURE.md
+
+> Status: **v0.1 DRAFT — unroasted**. Companion to `VISION.md`.
+> Contracts below are **shape sketches, normative**. They are not implementation and are not to be lifted into `src/`.
+
+---
+
+## 0. Invariants
+
+These are non-negotiable and every decision below is scored against them.
+
+| # | Invariant | Consequence |
+|---|---|---|
+| I1 | **Single spine.** Card is the only source of specimen truth. | No test may declare state the canvas can't render, and vice versa. |
+| I2 | **No hardcoded values.** Viewports, themes, budgets, colours, rung thresholds, canvas geometry — all resolved from token/policy sources. | Zero literals in logic. Polymorphic defaults resolve at runtime from the manifest chain. |
+| I3 | **Harness owns no rendering opinion.** | The harness must never import a component framework. |
+| I4 | **Evidence over assertion.** Status is derived from artefacts with provenance. | No writable status field anywhere. |
+| I5 | **Degrades to static.** Every mode must survive `build` → `file://`. | No mode may require a live server for *viewing*. |
+| I6 | **Deny by default.** Specimens get no ambient capability (network, storage, clipboard, media) unless the card requests it and it's granted. | Carries the Justified Capability Attestation pattern forward. |
+
+---
+
+## 1. Layer map
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  SHELL            Astro routes, static chrome, mode switch   │
+│                   zero-JS by default, islands only where     │
+│                   interaction is unavoidable                 │
+├──────────────────────────────────────────────────────────────┤
+│  LENSES           BENCH  │  CANVAS  │  GAUNTLET               │
+│                   three views over one registry              │
+├──────────────────────────────────────────────────────────────┤
+│  ORCHESTRATOR     specimen lifecycle, capability broker,      │
+│                   determinism injection, event tap,           │
+│                   evidence collection                         │
+├──────────────────────────────────────────────────────────────┤
+│  SUBSTRATE        isolation boundary (see D1)                 │
+│                   ← the one load-bearing unknown              │
+├──────────────────────────────────────────────────────────────┤
+│  REGISTRY         resolved specimen cards + evidence ledger   │
+├──────────────────────────────────────────────────────────────┤
+│  INGEST           CEM reader │ card reader │ token reader     │
+│                   Vite glob discovery, watch, invalidate      │
+└──────────────────────────────────────────────────────────────┘
+                            ▲
+                            │  (dev only)
+                   ┌────────┴────────┐
+                   │  SCRIBE plugin  │  write-back: layout,
+                   │  Vite middleware│  baselines, evidence
+                   └─────────────────┘
+```
+
+**Dependency rule:** strictly downward. Lenses never touch INGEST. SUBSTRATE never knows a lens exists. SCRIBE is dev-only and absent from the static build.
+
+---
+
+## 2. The spine — Specimen Card
+
+The card is the atom. Discovery produces cards; humans refine them; everything else consumes them.
+
+```ts
+// NORMATIVE CONTRACT SKETCH — shapes only, no impl
+interface SpecimenCard {
+  id: SpecimenId;               // stable, content-addressed, never a filepath
+  element: TagName;             // the custom element under test
+  source: SourceRef;            // module specifier, resolved by Vite
+
+  // WHAT TO RENDER  ── consumed by BENCH + CANVAS + GAUNTLET identically
+  states: StateDescriptor[];    // named prop/attr/slot configurations
+  matrix?: MatrixRef;           // viewport × theme × density axes, BY REFERENCE
+                                // (I2: never inline literals here)
+
+  // WHAT IT PROMISES  ── consumed by GAUNTLET, displayed by BENCH
+  contract: {
+    events?: EventDescriptor[];   // name, detail shape, when it must fire
+    slots?: SlotDescriptor[];
+    a11y?: A11yPolicyRef;         // by reference to policy set
+    budgets?: BudgetRef;          // by reference to budget set
+  };
+
+  // WHAT IT MAY DO  ── I6, brokered, never ambient
+  capabilities?: CapabilityRequest[];  // {capability, justification, tier}
+
+  // WHERE IT SITS  ── CANVAS only; separable, see D2
+  placement?: PlacementRef;
+}
+```
+
+**Resolution chain (polymorphic defaults, I2):**
+
+```
+project policy  →  package policy  →  card override  →  session override
+  (weakest)                                              (strongest, never persisted)
+```
+
+Nothing in the chain contains a literal that isn't a token reference. A viewport is `viewport.md`, not `768`. `768` lives in exactly one token file and is the token file's problem.
+
+---
+
+## 3. Ingest & discovery
+
+**Primary source: Custom Elements Manifest (CEM).** If a package publishes `custom-elements.json`, the harness reads tag names, attributes, properties, slots, events, and CSS parts from it and synthesises cards with `DECLARED` rung. Zero hand-config adoption (VISION §8) is bought here, or not at all.
+
+**Secondary: colocated card files.** `*.card.ts` next to the component, picked up by Vite glob import. Refines/overrides the CEM-derived card.
+
+**Tertiary: nothing.** No central registry file. No `main.js` config listing globs listing paths. Discovery is convention + manifest, and both are watchable.
+
+**Invalidate on:** component source change, card change, CEM change, token change, policy change. Each invalidation is scoped — a token change must not blow away the whole registry.
+
+---
+
+## 4. Substrate — isolation
+
+**The load-bearing decision. See D1.** What the layer must provide regardless of which way D1 lands:
+
+- `mount(card, state, env) → SpecimenHandle`
+- `SpecimenHandle`: measured box, event tap, capability channel, teardown, HMR re-mount preserving scroll/interaction where possible
+- `env`: injected determinism — seeded RNG, frozen clock, pinned locale/timezone, `prefers-*` overrides, forced viewport width **that media queries actually respect**
+
+That last point is the crux and quietly kills the easy options: a component with `@media (max-width: 480px)` inside it will not respond to a CSS-transformed 480px-wide div. If specimens must honour their own media queries at arbitrary canvas widths — and for responsive concept validation they must — the substrate needs real per-specimen viewport semantics. Container queries help *if the component was written with them*, which is not a constraint the harness can impose on components under test.
+
+---
+
+## 5. Canvas model
+
+**Live DOM under a transform, not a `<canvas>` bitmap.** Rasterising specimens forfeits inspection, interaction, a11y tree, and text selection — i.e. everything the harness is for. The word "canvas" here means *surface*, not the element.
+
+```
+World space (unbounded, specimen coordinates)
+    │  transform: scale(k) translate(x,y)   ← single compositor-friendly transform
+    ▼
+Viewport (the actual scroll-less DOM window)
+```
+
+- **Frames** group specimens into a named *concept*; a frame is itself a first-class node with its own attestation rollup.
+- **Overlay plane** (annotations, rung auras, measurement guides, connectors) renders in viewport space above the world, so overlay text does not scale into illegibility at low zoom. This is the correct call and slightly annoying to implement.
+- **LOD:** below a zoom threshold, specimens degrade live-DOM → last-known-baseline image → coloured rung block. Threshold from tokens (I2), not a magic number.
+- **Virtualisation** by world-space quadtree; specimens outside viewport + margin are unmounted or frozen. Unmount vs freeze is a real trade-off (state loss vs memory) and should be a per-card hint with a policy default.
+
+---
+
+## 6. Orchestrator
+
+**Event tap.** Every `CustomEvent` crossing a specimen boundary is captured with timestamp, detail, and composed path. This is simultaneously: the BENCH event log, the GAUNTLET's evidence that declared events fired, and the recording layer for interaction replay. One mechanism, three consumers — a small proof that I1 is real.
+
+**Capability broker (I6).** A specimen requesting `network`, `storage`, `clipboard`, or `media` gets a stub unless the card carries a justification and the tier is granted. Denied capabilities are *recorded*, not silently swallowed — an undeclared `fetch` attempt is itself evidence and should surface on the card.
+
+**Determinism envelope.** Injected before mount, uniformly across all three lenses. If BENCH and GAUNTLET see different clocks, visual baselines are noise and the whole ladder is a lie.
+
+---
+
+## 7. Evidence ledger & attestation
+
+Append-only. Each record: `{specimenId, rung, verdict, artefactRef, toolVersion, envHash, timestamp, signer}`.
+
+- Rung is **computed** by folding evidence, never written (I4).
+- `envHash` covers determinism envelope + token snapshot + substrate version. Evidence from a different `envHash` is *stale*, not *wrong*, and the UI must distinguish those.
+- Rung 6 (`ATTESTED`) requires a human signer and decays when any lower-rung evidence is invalidated. Human sign-off does not outrank a failing test.
+
+---
+
+## 8. Gauntlet binding
+
+Baseline checks are **generated from the card**, not authored. The runner is an adapter behind one interface so the choice (D4) stays reversible:
+
+```ts
+// NORMATIVE CONTRACT SKETCH
+interface GauntletAdapter {
+  plan(cards: SpecimenCard[]): TestPlan;   // card → cases, no hand-written glue
+  run(plan: TestPlan, env: DeterminismEnv): Promise<EvidenceRecord[]>;
+}
+```
+
+Requirement that constrains D4 hard: the runner must mount specimens through **the same substrate** as the canvas. Two mounting paths = two behaviours = baselines that pass in CI and lie on screen.
+
+---
+
+## 9. Build topology
+
+| Phase | Astro | Vite | Notes |
+|---|---|---|---|
+| dev | dev server, routes, chrome | HMR, glob discovery, SCRIBE middleware | SCRIBE is the only write path to disk |
+| build | static shell per route, prerendered card index | specimen chunks, code-split per component | registry serialised as static JSON |
+| static view | — | — | canvas + bench read serialised registry; gauntlet unavailable, degrades visibly (I5) |
+
+Astro earns its place by: static chrome with genuinely zero framework JS, content collections as a natural fit for the card registry, and clean per-mode routing. If in practice the canvas becomes one big island and Astro is reduced to a shell server, that's kill-criterion territory (`VISION §9`) — call it early, don't cargo-cult it.
+
+---
+
+## 10. Open decisions — ROAST THESE
+
+**D1 — Isolation substrate.** *Blocks everything.*
+
+| Option | Style isolation | Media queries | HMR | Cost/specimen | Verdict |
+|---|---|---|---|---|---|
+| Same document | none (global leak) | ✗ broken | trivial | ~0 | fast, lies |
+| Shadow root wrapper | good (not perfect: inherited props, global sheets) | ✗ still viewport-wide | easy | low | tempting, still lies about responsive |
+| iframe per specimen | true | ✓ real | painful across boundary | high (~MBs) | honest, expensive |
+| iframe pool + recycling | true | ✓ real | painful | medium | complex, probably correct |
+
+Leaning: **iframe with recycling pool, LOD-driven** — only specimens above the interactive zoom threshold get a live iframe; the rest are baseline images or rung blocks. Buys honesty and bounds the cost. Costs: an HMR bridge and a message-passing layer that touches every other subsystem. Roast this hardest; it's the decision the project lives or dies on.
+
+**D2 — Layout persistence.** Committed `layout.json` (reviewable, diffable, merge-hostile) vs local-only (frictionless, ephemeral, kills VISION §5 "concept in a PR") vs hybrid: committed *named concepts* + local scratch space. Hybrid is probably right and is the most work. Also: how does layout survive a specimen id change?
+
+**D3 — Card authorship.** CEM-derived + `*.card.ts` overlay (proposed) vs cards as the only source vs cards inside the component file as static metadata. CEM buys zero-config adoption but CEM's coverage of *states* is thin — it describes the API surface, not interesting configurations. Is the overlay actually carrying 90% of the weight, making "zero-config adoption" a hollow claim?
+
+**D4 — Runner.** Vitest browser mode vs Playwright component-testing vs Playwright driving the harness itself as a page. Third option is odd but respects §8's same-substrate constraint for free, since it literally uses the harness. Downside: slow, and CI now depends on the whole app booting.
+
+**D5 — Rung computation locus.** Client-side fold over the ledger (live, cheap, degrades with ledger size) vs SCRIBE-computed on write (fast reads, needs the dev server, breaks I5 for status display in static builds).
+
+**D6 — Specimen identity.** Content-addressed from `{package, element, stateName}` (stable across moves, changes when you rename a state — nuking your layout and baselines) vs explicit human-assigned id (stable, requires discipline, collides). Renaming a state should not detonate history; neither should copy-paste create phantom identity.
+
+---
+
+## 11. Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| HMR through iframe boundary (D1) | fatal — kill criterion | prototype **first**, before any other work; timebox it |
+| Canvas perf at realistic specimen counts | severe | LOD + virtualisation designed in from day one, not retrofitted |
+| CEM ecosystem coverage thinner than assumed | undermines zero-config claim | survey real packages before committing to D3 |
+| Astro reduced to a shell server | architectural embarrassment | explicit checkpoint at v0.3 — keep or drop, no sunk cost |
+| Scope: three products in one (VISION V3) | schedule death | consider GAUNTLET as v2 |
+| Visual baselines flaky across environments | ladder becomes noise | `envHash` gating + containerised baseline capture |
+
+---
+
+## 12. Proposed sequence
+
+Doc-first, per the rules. Nothing below starts until this doc is signed.
+
+0. **Sign-off + D1–D6 resolved** (or explicitly deferred with a written reason)
+1. **Spike: D1.** Isolation + HMR + forced-viewport media queries. Throwaway code, one question: does the honest option work? Kill criterion evaluated here.
+2. **Spine.** Card schema, resolution chain, token/policy sources, CEM ingest.
+3. **BENCH.** Cheapest lens, proves the spine end to end.
+4. **CANVAS.** Transform, frames, LOD, virtualisation, D2 persistence.
+5. **Ladder rungs 0–2.** Derived status with no test runner at all — proves I4 before GAUNTLET exists.
+6. **GAUNTLET** — or defer to v2 per V3.

--- a/docs/testing-harness/DECISIONS.md
+++ b/docs/testing-harness/DECISIONS.md
@@ -1,0 +1,154 @@
+# VITRINE — DECISIONS.md
+
+> The register. Every open question raised anywhere in the doc set, in one place, with dependency order.
+> Source docs remain authoritative for *reasoning*; this file is authoritative for *status*.
+> Status: **v0.2** · verified against doc set 2026-07-27.
+
+---
+
+## Tally
+
+| | Count |
+|---|---|
+| Raised across the doc set | twenty-five |
+| Resolved | two |
+| Reclassified | one |
+| **Open** | **twenty-two** |
+| Open and blocking | one |
+
+Raised: VISION four (`V*`), ARCHITECTURE six (`D*`), UX-STACK five (`S*`), SPINE five (`O*`), PROVISIONING five (`P*`).
+Resolved: `D3` and `D6`, both by `SPINE.md`.
+Reclassified: `D4`, by `PROVISIONING.md` — it was never a decision.
+
+---
+
+## The blocking one
+
+### D1 — Isolation substrate · **OPEN · BLOCKS EVERYTHING DOWNSTREAM OF THE SPINE**
+
+*Raised:* `ARCHITECTURE.md §10` · *Pressurised:* `UX-STACK.md §7` · *Contained:* `SPINE.md §5`
+
+Same-document and shadow-root are cheap and lie about responsive behaviour. iframes are honest and expensive — and under a continuously animating world transform they may be untenable at any useful density.
+
+Live options: **(a)** iframes, accept low-density SANDBOX; **(b)** shadow-root, sacrifice real media queries, require container queries from components under test; **(c)** hybrid promote-on-focus, which needs a written exception to `ARCHITECTURE.md §8`'s same-substrate rule.
+
+*Mitigated by:* `SPINE.md §5` — cards declare traits, `policy/substrate.toml` maps traits to strategy. When this resolves, one file changes and no card is touched. **The spine is therefore buildable before D1 resolves.**
+
+*Reframed by `PROVISIONING.md §6`, not resolved:* the three options are now **providers** of one requirement, ranked by one conformance suite. They stop competing as arguments and start being measured. What does not change: nobody knows yet whether *any* provider clears 120fps under continuous transform. That question is empirical and still blocks.
+
+*Resolution gate:* the spike. Pass/fail on: honest media queries at forced widths, HMR through the boundary, and N specimens at 120fps under continuous `matrix3d()`.
+
+---
+
+## Reclassified
+
+### D4 — Runner · **NOT A DECISION** · *pending sign-off*
+
+> `ARCHITECTURE.md §10` still carries D4 as open. That is correct until `PROVISIONING.md §9` is approved — the proposal does not get to edit other docs before it is accepted. Same for `TESTING.md`'s "blocked on D4". Known, tracked, not drift.
+
+*Was:* Vitest browser mode vs Playwright CT vs Playwright driving the harness.
+
+*Now:* a **binding**. Runners are providers of the "execute a test plan" requirement, selected per profile by conformance evidence, replaceable by a refactor procedure. `PROVISIONING.md §1 F4, §6`.
+
+The same-substrate constraint from `ARCHITECTURE.md §8` survives as a **conformance requirement**, which is stronger than it was as prose: a runner that mounts specimens differently from the canvas fails the suite rather than being caught in review.
+
+---
+
+## Resolved
+
+| | Decision | Resolution |
+|---|---|---|
+| **D3** | Card authorship | CEM skeleton + `*.card.ts` overlay, merged at the overlay stage. Cards are pure data; builders emit plain documents. `SPINE.md §4, §7`. **Contingent on O2.** |
+| **D6** | Specimen identity | Opaque ULIDs minted once into `vitrine.lock`; names are labels; `SpecimenId = hash(CardId, StateId, canonical(AxisVector))`. Renames are free, rebinds are proposed and never silent. `SPINE.md §2`. **Contingent on O1.** |
+
+Both resolutions have a live objection against them. Neither is safe to treat as settled.
+
+---
+
+## Open — scope
+
+Answer these before build order matters, because they change what gets built.
+
+**V3 — Is GAUNTLET in v1?** As written this is three products in a trenchcoat. Honest minimum: BENCH + CANVAS + rungs through `RENDERS`, with the test runner deferred. *Interacts with D4, S5.*
+
+**S5 — Is the engine ambition real?** The cheapest honest answer is: build the sandbox with wgpu and let the native engine earn its existence later, or never. The risk is that engine ambition makes every decision three times more expensive for a future that does not arrive. *Interacts with S2, S3.*
+
+**V1 — Seven rungs or three?** `RENDERS / BEHAVES / PINNED` is the defensible minimum. Seven may be ceremony that produces a pretty canvas and no information. *Cheap to defer — the fold is a pure function over evidence; add rungs later without migration.*
+
+**V4 — Is the agent persona real work now?** Or is it a manifest-format constraint that costs nothing to honour and everything to build for? *Currently costs nothing: the spine is already serialisable data.*
+
+---
+
+## Open — architecture
+
+**D2 — Layout persistence.** Committed (reviewable, merge-hostile) vs local-only (frictionless, kills "concept in a PR") vs hybrid named-concepts-plus-scratch. Hybrid is probably right and is the most work. *Partially eased by D6: opaque ids mean layout survives renames.*
+
+**D5 — Rung computation locus.** Client-side fold (live, degrades with ledger size) vs SCRIBE-computed on write (fast, breaks I5 for static builds). *Leaning client-side with a serialised snapshot for static builds — probably decidable now, cheaply.*
+
+**O3 — Axis expansion blowup.** Four states × five viewports × two themes × two densities is eighty specimens per component. Evidence, baselines and canvas cost all scale with that product. Sparse per-state axes, sampling policy, or on-demand expansion with cached rungs. *Unspecified. Will bite in week two.*
+
+**O5 — Provenance cost.** Provenance on every resolved value is correct and possibly expensive in a hot path. Wants resolve-once-cache-hard, but then session overrides need precise invalidation.
+
+---
+
+## Open — objections to things marked resolved
+
+**O1 — Is minted identity over-engineering?** Buys rename-safety; costs a SCRIBE write path, a merge-conflict surface, and a rebind ritual. Alternative: renames nuke baselines, don't rename. *If this falls, D6 falls with it.*
+
+**O2 — Does CEM carry real weight?** If CEM gives tag names and attribute types while the overlay carries all states, port schemas, traits and fixtures, then "zero-config adoption" gets you an empty card at `DECLARED`. **This is the assumption most likely to be wrong, and it is cheap to check.** *If this falls, D3's premise falls and VISION's success criterion needs rewording.*
+
+**O4 — Fixtures as escape hatch.** "Cards are pure data" holds only while fixtures stay small. Nothing currently stops a fixture becoming the actual configuration, at which point purity is theatre and the static build breaks. *Needs a constraint that is not yet written.*
+
+---
+
+## Open — provisioning
+
+Raised by `PROVISIONING.md §10`. P1 gates the rest.
+
+**P1 — Is negotiated provisioning justified at this scale?** Terraform-grade machinery for a solo tool may be the most over-engineered thing in the doc set. Counter: without it, `UX-STACK.md` is a set of welds and the stated philosophy is implementation-agnostic-until-inconvenient. *Argue before building anything under `PROVISIONING`.*
+
+**P2 — Requirement granularity.** Too coarse and providers are unswappable monoliths; too fine and the project dies of interfaces. Working suspicion — a requirement is worth declaring only where a conformance suite is worth writing — is a nice test and possibly circular.
+
+**P3 — Does negotiation purity survive npm?** Pure only while probes are cached and no version resolution happens during it. May force providers to pin exact versions and never ranges.
+
+**P4 — Cross-ecosystem locks.** Does the binding lock reference, contain, or generate the Rust and Node locks? Referencing is cheapest and leaves two sources of truth.
+
+**P5 — `PROVISIONAL` decay.** Nothing currently forces a provisional binding to clear. Expiry that fails CI is honest and will be hated on the day it fires; the alternative is the state quietly becoming permanent, which is what it was invented to prevent.
+
+---
+
+## Open — stack
+
+**S1 — Browser-first: cowardice or correctness?** Costs the native-feel story and filesystem access for a year. The alternative is eating WebKitGTK now and designing down to it, which probably means abandoning the FabFilter motion premise. *Evidence is on the browser-first side; this is here to be argued, not assumed.*
+
+**S2 — `bevy_ecs` standalone vs hand-rolled entity store.** ECS for a few hundred entities is arguably ceremony. It is also what makes a native runtime a port rather than a rewrite. *Downstream of S5.*
+
+**S3 — Command protocol vs direct wasm bindings.** Per-frame serialisation cost is real and paid today; the portability it buys is claimed for phase three. *Downstream of S5.*
+
+**S4** — is D1 restated from the sandbox side. Tracked under D1, not separately.
+
+**V2 — Does committed layout poison every diff?** Realistically: does `concepts/*.json` get `.gitignore`'d by week two? *Same question as D2 from the vision side.*
+
+**Astro checkpoint** — not lettered, from `VISION.md §9` and `UX-STACK.md §3`. If CANVAS becomes one giant island, Astro is a shell server and this is a Vite app. Explicit review at v0.3, no sunk cost.
+
+---
+
+## Dependency order
+
+```
+O2 (survey CEM)  ──▶ D3 stands or falls        [cheap, do first, no code]
+O1 (identity)    ──▶ D6 stands or falls        [argument, no code]
+V3 + S5 (scope)  ──▶ what gets built at all    [argument, no code]
+P1 (provisioning)──▶ how much machinery        [argument, no code]
+        │
+        ▼
+   SPINE BUILD  ────────────────────────────── [D1-independent, per SPINE §5]
+        │
+   D1 SPIKE  ─────▶ substrate binding, D2      [throwaway code, hard gate]
+        │            runner binding follows free
+        │
+   O3, O5, D5  ───▶ scale and perf             [decidable during build]
+   P2..P5      ───▶ only if P1 lands yes
+```
+
+Five things above the line are arguments, not code. Three are settleable in an afternoon. **Nothing should be written until O2's survey is done and V3, S5 and P1 are called** — those change the shape of the thing, not just its details.

--- a/docs/testing-harness/GLOSSARY.md
+++ b/docs/testing-harness/GLOSSARY.md
@@ -1,0 +1,103 @@
+# VITRINE — GLOSSARY.md
+
+> Vocabulary is load-bearing here. The card/specimen conflation in `ARCHITECTURE §2` was a *naming* failure that would have become a data-model failure. Words are pinned so that does not happen twice.
+
+---
+
+## The spine
+
+**Card** — a *family*. One component plus its declared states, ports, contract, traits and capability requests. Authored by humans, colocated with the component. Pure data. Never has placement, never has evidence.
+
+**State** — one named configuration within a card: props, attrs, slots, context, preconditions. A label plus a minted `StateId`.
+
+**Axis** — a dimension of variation declared in `axes/`: viewport, theme, density, locale, motion. Referenced by cards, never inlined.
+
+**Specimen** — a *point*. One card, one state, one axis vector. Derived by expansion, never authored. Everything downstream — evidence, baselines, placement, wires — addresses specimens.
+
+**Expansion** — the pure, deterministic transform from cards × axes to specimens. The only place families and points meet.
+
+**Locator** — `{package, element, cardName}`. Derived, mutable, human-readable, **never load-bearing**. Renaming changes the locator and nothing else.
+
+**Lock** (`vitrine.lock`) — git-tracked record of minted identities and rebind history. The only file SCRIBE writes to the spine.
+
+**Rebind** — the operation when a state disappears and an unfamiliar one appears in the same card. Always *proposed*, never automatic, because a wrong rebind silently poisons baseline history.
+
+**Fixture** — a value that cannot be pure data: live objects, large markup, generated content. Referenced by id, resolved by the substrate at mount. An escape hatch under active suspicion (O4).
+
+**Trait** — a *fact* about a component (`ownMediaQueries`, `statefulMount`, `heavyInit`, `globalSideEffects`). Cards declare facts; `policy/substrate.toml` maps facts to strategies. This is what keeps D1 out of every card.
+
+**Port** — a wire endpoint. `OutPort` is an event plus a detail schema reference; `InPort` is a prop plus an accepted schema reference. Connection is legal iff the resolver proves assignability.
+
+---
+
+## Evidence
+
+**Evidence record** — an append-only ledger entry: specimen, check, verdict, artefact, `envHash`, tool version, timestamp, optional signer.
+
+**envHash** — hash over the determinism envelope, token snapshot and substrate version. Evidence from a different `envHash` is **stale**, not **failed** — a distinction the UI must preserve and never collapse.
+
+**Rung** — a maturity level, computed by folding evidence. Never written. The ladder: `DECLARED`, `STUB`, `RENDERS`, `BEHAVES`, `ACCESSIBLE`, `PINNED`, `ATTESTED`. (Whether all seven survive is V1.)
+
+**Fold** — the pure function from evidence to rung. Specimen rung is the highest rung whose checks all currently pass; **card rung is the minimum over its specimens**, because averaging produces a comfortable number and a false one.
+
+**Attestation** — rung `ATTESTED`. Requires a human signer and **decays when any lower-rung evidence is invalidated**. Sign-off never outranks a failing test.
+
+**Provenance** — the layer chain behind a resolved value or a status claim. Applies to config as well as evidence: the UI must be able to answer *"why is this viewport 768?"*.
+
+---
+
+## Lenses and surfaces
+
+**BENCH** — single specimen, full viewport, controls, event log, inspector. The building-the-thing lens.
+
+**CANVAS** — pan/zoom surface holding live DOM specimens under one world transform. The comparison and concept-validation lens. The reason the project exists.
+
+**GAUNTLET** — the prove lens. Baseline checks generated from cards, not authored. May be deferred to v2 (V3).
+
+**SANDBOX** — the GMod-flavoured interaction layer over CANVAS: tool modes, direct manipulation, wires. Not a fourth lens; a way of operating the third.
+
+**Concept** — a named frame grouping specimens on the canvas. A first-class node with its own attestation rollup. Lives in `concepts/`, keyed by `SpecimenId`.
+
+**Wire** — a rendered `out.event → in.prop` connection in world space. Pulses when the event fires. Built from the orchestrator's existing event tap, which is I1 paying rent a third time.
+
+---
+
+## Runtime
+
+**Substrate** — the isolation boundary. Provides mount, teardown, measured box, event tap, capability channel, determinism injection, HMR re-mount. **Unresolved (D1).**
+
+**Determinism envelope** — seeded RNG, frozen clock, pinned locale and timezone, `prefers-*` overrides, forced viewport. Injected identically across all lenses; if BENCH and GAUNTLET see different clocks, every baseline is noise.
+
+**Event tap** — capture of every `CustomEvent` crossing a specimen boundary. One mechanism, three consumers: the BENCH log, GAUNTLET's evidence, and the sandbox's wire pulses.
+
+**Capability broker** — grants or stubs `network`, `storage`, `clipboard`, `media` per I6. Denied use is *recorded as evidence*, never silently swallowed.
+
+**SCRIBE** — the dev-only Vite middleware that writes to disk: lock, layout, baselines, evidence. Absent from static builds by construction.
+
+**World space / viewport space** — specimen coordinates vs the DOM window. One camera matrix, owned by `core-scene`, published to both the DOM and GPU planes so they cannot desync. Overlays render in viewport space so text stays legible at low zoom.
+
+**LOD** — degradation ladder: live DOM → last-known baseline image → coloured rung block. Thresholds from tokens.
+
+---
+
+## Interaction
+
+**Disclosure level** — `AMBIENT`, `PROXIMATE`, `FOCUSED`, `EDITING`, `EXPERT`. Additive overlays on a fixed layout.
+
+**The superset law** — expert is a strict superset of every level below it *in the same spatial arrangement*. Nothing visible ever moves when you level up. Forces layout to be designed for expert first and subtracted downward. Executable as a test (`TESTING §4`).
+
+**Tool mode** — `PLACE`, `GRAB`, `WIRE`, `PROBE`, `MEASURE`, `ATTEST`. The mode decides what a click means. Held and chorded, never a click target.
+
+**Modifier grading** — same gesture, different resolution. The physgun and the FabFilter drag are the same primitive.
+
+**Retarget** — a spring changing destination mid-flight without restarting. Why the integrator is hand-rolled rather than CSS keyframes.
+
+---
+
+## Borrowed terms
+
+**CEM** — Custom Elements Manifest, `custom-elements.json`. The zero-config ingest path. Its actual coverage is unverified (O2).
+
+**JCA** — Justified Capability Attestation. The tier model carried over from prior work: a capability request must carry a justification, and the grant is policy's decision, not the requester's.
+
+**Concept in a PR** — the claim that canvas layout is a reviewable committed artifact rather than local ephemera. Contested (D2, V2).

--- a/docs/testing-harness/HOUSE_RULES.md
+++ b/docs/testing-harness/HOUSE_RULES.md
@@ -1,0 +1,106 @@
+# zenOS Testing Harness — House Rules
+
+> Normative for agents and humans working in zenOS. Maps VITRINE invariants to this repo.
+> Reference spine: [`TESTING.md`](TESTING.md) · provisioning: [`PROVISIONING.md`](PROVISIONING.md)
+
+---
+
+## 1. Default harness
+
+**VITRINE** (documented in this directory) is zenOS's **default testing harness reference**. It is design-first — no VITRINE runtime ships in zenOS yet. Until it does:
+
+| Today (zenOS) | VITRINE layer (target) |
+|---|---|
+| `pytest` + `tests/` | Rust unit + property (spine crates) |
+| `test_runner.py` | Transitional smoke runner — not the harness |
+| `zen/testing/hydrate.py` | DECLARE → NEGOTIATE → HYDRATE provisioning |
+| `tokens/testing-harness.toml` | Token store (I2) |
+| `zenos.stack.lock` | Binding lock for stack providers |
+| `.github/workflows/zenos-ci.yml` | CI shape from `TESTING.md §7` |
+
+Do not invent a second harness philosophy. Extend VITRINE docs here; implement against them.
+
+---
+
+## 2. Invariants (scored on every change)
+
+| ID | Rule | zenOS enforcement |
+|---|---|---|
+| **I1** | Single spine — one source of specimen/procedure truth | Cards/procedures in dex + `procedures/`; tests derive from declared manifests |
+| **I2** | No hardcoded values — literals only in `tokens/` and binding lock | CI budgets, perf `N`, timeouts → `tokens/testing-harness.toml` |
+| **I3′** | Harness owns no stack opinion | Framework names only in `zenos.stack.lock`; code imports capabilities, not providers |
+| **I4** | Evidence over assertion | CI results and ledger-style journals; no hand-written "passing" status |
+| **I5** | Degrades to static | Docs and smoke tests runnable without live services where possible |
+| **I6** | Deny by default | Capabilities (network, fs, secrets) explicit in cards/procedures |
+| **I7** | One mutation path | All dep/state change via `zen.testing.hydrate` plan/apply + journal |
+
+`I3′` and `I7` follow [`PROVISIONING.md §9`](PROVISIONING.md) — applied in zenOS even while VITRINE core remains design-only.
+
+---
+
+## 3. Token discipline (tokenmaxxed)
+
+- **Scalars live in `tokens/`** — viewport widths, perf gate `N`, provisional binding TTL, pytest timeouts.
+- **Versions and package names live in `zenos.stack.lock`** — the second literal store (I2 exemption per PROVISIONING §2).
+- **Docs reference tokens by key**, not by repeating numbers (`testing.perf.specimen_count`, not "120 specimens").
+- **Agents:** read tokens before guessing literals. If a value is missing, add it to tokens — do not inline.
+
+---
+
+## 4. Startup handshake (abstracted hydration)
+
+All programmatic environment startup follows three phases from [`PROVISIONING.md §3`](PROVISIONING.md):
+
+```
+DECLARE   → read requirements, probes, profile (read-only)
+NEGOTIATE → pure proposal: bindings + dependency delta (no mutation)
+HYDRATE   → journaled plan/apply only (mutating)
+```
+
+**CLI:**
+
+```bash
+python -m zen.testing.hydrate declare --profile ci/headless
+python -m zen.testing.hydrate negotiate --profile ci/headless
+python -m zen.testing.hydrate hydrate --profile ci/headless   # applies approved plan
+python -m zen.testing.hydrate status                          # observe without mutate
+```
+
+**Halt conditions** (exit non-zero, change nothing): unresolved requirement, binding change without approval, ungranted capability, lockfile disagreement with plan.
+
+Unified setup (`python setup.py`) should call HYDRATE for the active profile — not raw `pip install` in automation paths.
+
+---
+
+## 5. Testing before implementation
+
+Per [`TESTING.md §0`](TESTING.md): the harness tests itself through the public spine once it can render anything. For zenOS today:
+
+1. Spine-adjacent logic (resolver, identity, negotiation purity) → unit/property tests first.
+2. Chrome/UI dogfood → after spine tests pass.
+3. Browser/substrate conformance → after D1 lands in VITRINE implementation.
+
+**Bootstrap order matters.** Do not add browser e2e for harness chrome before spine tests exist.
+
+---
+
+## 6. CI gates (aligned with TESTING §7)
+
+| Stage | Gate | Workflow job |
+|---|---|---|
+| Lint + format | must pass | `lint` |
+| Python unit + property | must pass | `test` |
+| Smoke / integration | must pass | `test` (pytest) |
+| Security scan | advisory | `security` |
+| Shell validation | advisory | `shell-check` |
+| Docs build | advisory | `docs` |
+| Harness validate | negotiation purity + token lint | `harness-validate` |
+| Offline bootstrap | future: engine build network-off | not yet |
+
+---
+
+## 7. Open (zenOS-specific)
+
+- **H1.** When VITRINE runtime lands, does it live in-repo or as a pinned provider in `zenos.stack.lock`?
+- **H2.** Map zenOS plugins (`examples/sample-plugin`) to Card overlays — schema TBD.
+- **H3.** Dex procedures as GAUNTLET plans — `zen.test.harness` procedure evolution path.

--- a/docs/testing-harness/PROVISIONING.md
+++ b/docs/testing-harness/PROVISIONING.md
@@ -1,0 +1,274 @@
+# VITRINE — PROVISIONING.md
+
+**Stack negotiation, idempotent init, and refactor procedures.**
+
+| | |
+|---|---|
+| Status | **PROPOSED — awaiting operator sign-off** |
+| Normative | Yes. Amends `ARCHITECTURE.md`, `UX-STACK.md`, `TESTING.md`, `DECISIONS.md` — see §9. |
+| Supersedes | Nothing. Reframes `UX-STACK.md` (see §1, F1). |
+| Blocks | Any dependency being added to any manifest by any means. |
+| Verified against | doc set as of 2026-07-27 |
+
+---
+
+## 1. Review findings — what this requirement breaks
+
+Leading with the damage, because the requirement invalidates a framing I shipped two turns ago.
+
+### F1 — `UX-STACK.md` is mis-framed and must be demoted
+
+I wrote it as a decision record: Astro, React, wgpu, `bevy_ecs`, browser-first, not-Tauri. Those recommendations remain evidence-backed and I stand behind the *reasoning*. But the document presents them as **axioms**, and under a negotiated-stack model no dependency may be an axiom. It is a **resolved binding snapshot for one target profile** — `linux/wayland/chromium/dev` — and nothing more.
+
+Concretely: nothing in `core-render` may name wgpu. Nothing in the shell may name Astro. Those names appear in exactly one place, the binding lock, and everything else addresses the *capability*.
+
+This is the same mistake in a different coat as the card/specimen conflation owned in `SPINE.md §0`: I let a concrete choice sit where an abstraction belonged.
+
+### F2 — Invariant I3 is too narrow
+
+"The harness owns no rendering opinion" was written about component frameworks. The correct generalisation is **the harness owns no stack opinion**. Restated in §9 as I3′.
+
+### F3 — I2 has an unhandled literal class
+
+`tokens/` is declared the only place a literal may exist. Dependency versions, registry URLs and package names are literals and have no home. Left unaddressed, every manifest becomes an I2 violation the moment it exists. Resolved in §2 by making the binding lock a token space with a formal exemption, not by pretending versions aren't literals.
+
+### F4 — D4 was never a decision
+
+`DECISIONS.md` carries D4 as "pick a runner: Vitest browser mode vs Playwright CT vs Playwright driving the harness." Under this model that is not a decision — it is a **binding**, chosen per profile by evidence, replaceable by a refactor procedure. Reclassified in §9.
+
+### F5 — D1 changes shape but does not go away
+
+The substrate is a capability with three candidate providers and a conformance suite already specified (`TESTING.md §3`). Negotiation does not answer whether *any* provider clears 120fps under continuous transform. That question is empirical and still blocking. What changes: D1 stops being "choose one and weld it in" and becomes "run the suite, let evidence bind, keep the losers as providers."
+
+### F6 — the honest risk, stated once
+
+**The failure mode of this entire document is building a second, worse package manager.** If the negotiation engine starts resolving version ranges, walking dependency graphs, or fetching tarballs, it is dead and it has taken the project with it. The engine **plans and delegates**; npm and cargo do the work. Every design choice below is subordinate to that constraint. If a feature requires the engine to understand semver ranges, cut the feature.
+
+---
+
+## 2. The model — requirements, providers, bindings
+
+The stack becomes a card. Same shape as `SPINE.md §5`, one layer up.
+
+| Spine (runtime) | Provisioning (build) |
+|---|---|
+| card declares **traits** (facts) | component declares **requirements** (capabilities) |
+| policy maps traits → **strategy** | negotiation maps requirements → **providers** |
+| one file changes when D1 lands | one lock changes when a stack choice moves |
+
+```
+REQUIREMENT     a capability the system needs, with a conformance suite
+                "isolate a specimen"  ·  "render a GPU world plane"
+                "serve static chrome" ·  "execute a test plan"
+
+PROVIDER        a concrete adapter that claims a requirement, declaring:
+                dependency footprint · target profiles supported
+                capability requests (network, fs, native toolchain)
+                conformance evidence
+
+BINDING         requirement × profile → provider, recorded with provenance
+                lives in vitrine.stack.lock, git-tracked, human-diffable
+
+PROFILE         a named target: linux/wayland/chromium/dev
+                                ci/headless · static/file · native/vulkan
+```
+
+**Requirements are declared in documents; providers are discovered; bindings are negotiated and locked.** No source file imports a provider directly — it imports the requirement's interface, and the glue is generated at hydrate.
+
+**F3's resolution:** `vitrine.stack.lock` is a token space. Package names, versions and registry URLs are literals *there* and nowhere else, exactly as `768` lives in `tokens/` and nowhere else. I2 holds by the same mechanism it already uses; it just gains a second store with an explicit, narrow exemption.
+
+---
+
+## 3. The handshake
+
+Three phases, hard-separated. Phase boundaries are the only places state may change.
+
+### DECLARE — pure, offline, no mutation
+
+Both sides state facts.
+
+- **System declares:** requirements, constraints (license policy, version floors, capability budget), target profile.
+- **Environment declares:** probe results — OS, package managers present, toolchain versions, GPU adapters, browser availability, network reachability, existing manifests and locks.
+
+Probes are read-only, cached with a TTL, and their results are provenance-tagged. **A probe that mutates anything is a bug, not a probe.**
+
+### NEGOTIATE — pure, offline, produces a proposal
+
+Resolution walks requirements against discovered providers under the profile and constraints, and emits a **Proposal**: a set of bindings, the dependency delta implied, capability requests raised, and full provenance for every choice.
+
+```
+Proposal {
+  profile, bindings[], deltaAdd[], deltaRemove[], deltaChange[],
+  capabilityRequests[], provenance[], conformanceStatus[], warnings[]
+}
+```
+
+Negotiation is a **pure function** of declared inputs. Same inputs, same proposal, byte-identical. This is what makes the whole thing testable without a network and reviewable as a diff.
+
+**Halt conditions — no silent fallback, ever:**
+
+- no provider satisfies a requirement under the profile → **HALT**
+- multiple providers tie with no policy tiebreak → **HALT**
+- a provider lacks conformance evidence for this profile → **HALT** (or bind `PROVISIONAL`, see §6)
+- the proposal changes an existing binding → **HALT for approval**, always, no exceptions
+- a capability request is ungranted → **HALT**
+
+Halt means: print the proposal with reasons, exit non-zero, change nothing. Degrading to a weaker provider without saying so is the exact failure this architecture exists to prevent.
+
+### HYDRATE — the only mutating phase
+
+Executes an approved plan. Everything in §4 applies.
+
+---
+
+## 4. Idempotence
+
+Stated as properties, because "idempotent" without properties is a vibe.
+
+| | Property |
+|---|---|
+| **P-conv** | `apply(plan)` run N times converges to the same state as N=1 |
+| **P-noop** | applying to an already-converged state performs zero mutations and exits zero |
+| **P-resume** | an interrupted apply, re-run, either completes or aborts cleanly — never half-state |
+| **P-pure** | desired state is a pure function of declarations, probes and policy |
+| **P-observe** | actual state is observable without mutation |
+| **P-journal** | every mutation is journaled before it happens and confirmed after |
+
+### Mechanism — plan/apply with a journal
+
+```
+desired = f(declarations, probes, policy)      pure
+actual  = observe()                            read-only
+plan    = diff(desired, actual)                pure, ordered, content-addressed
+apply(plan)                                    journaled, step-idempotent
+```
+
+Each step declares its own **precondition**, **effect**, and **postcondition**. A step whose postcondition already holds is skipped, not repeated — that is where P-noop comes from, not from wrapping the whole thing in a flag file.
+
+The **journal** is append-only JSONL with the same record shape as the evidence ledger. Not a coincidence and not reuse-for-its-own-sake: provisioning history is evidence, it wants provenance and `envHash`, and the ledger already does that. I1 paying rent a fourth time.
+
+### The uncomfortable part
+
+Package managers are not idempotent. `npm install` can produce different trees from identical inputs; `cargo add` mutates a manifest with formatting opinions.
+
+Containment:
+
+- the harness **never** invokes a resolving install. Lockfiles are desired state; installs are deterministic replays (`npm ci` and equivalents).
+- manifest edits are performed by the harness against a parsed AST, deterministically formatted, and **verified by re-parse** before the step's postcondition passes.
+- if a package manager produces a lock that disagrees with the plan, that is a **halt**, not a merge. The engine does not negotiate with the resolver — F6.
+
+### Crash safety
+
+Journal-before-mutate gives resumability. On start, an unterminated journal entry means the last apply was interrupted: re-observe, re-plan, and the plan naturally omits whatever already landed. **No rollback machinery.** Rollback of a partial dependency install is a fantasy; convergence is achievable and rollback is not.
+
+---
+
+## 5. Refactor procedures
+
+A refactor is a **declared document**, never a script. "Swap the runner", "move the substrate from shadow-root to iframe pool", "add a native profile" are all the same kind of object.
+
+```
+Procedure {
+  id, description
+  preconditions[]        must hold or HALT
+  bindingChanges[]       requirement → new provider
+  migrations[]           codemods, config rewrites, evidence remapping
+  postconditions[]       must hold or the procedure did not happen
+  evidenceDisposition    preserve | stale | invalidate   ← mandatory, no default
+  reversible             bool; irreversible procedures say so loudly
+}
+```
+
+Rules:
+
+- a procedure runs through the same plan/apply path as init. **There is one mutation path.** A second one would be a second source of truth about state, which is the thing this project is against.
+- procedures are idempotent by the same properties. Running one twice is a no-op with a message.
+- **`evidenceDisposition` has no default.** Changing the substrate invalidates every visual baseline; changing the runner probably does not; changing a token snapshot makes evidence stale rather than wrong. Getting this wrong silently is how a maturity ladder starts lying, so the procedure author must state it.
+- a procedure that would drop any card's rung reports the drop in the proposal, before approval.
+
+---
+
+## 6. Conformance as the acceptance gate
+
+This is the finding that makes the whole thing hold together, and it was already sitting in `TESTING.md §3` doing a smaller job.
+
+**A requirement owns a conformance suite. A provider is bound only if it passes that suite under the target profile.**
+
+Consequences, in order of how much I like them:
+
+1. **The testing harness is the negotiation validator.** "A testing harness that can dynamically change stack dependencies" is not two features bolted together — the harness is the thing that licenses the change. There is no other mechanism by which a provider becomes trustworthy.
+2. **Provider swaps become safe by construction.** Vitest and Playwright are interchangeable exactly insofar as both pass the runner conformance suite. If they diverge, the suite is the diff.
+3. **The suite outlives the decision.** Written to settle D1, it becomes the permanent regression net for whatever wins, and the entry exam for anything proposed later.
+4. **D1's three options stop competing and start being measured.** All three become providers; the suite ranks them; the binding records which won and why.
+
+Binding states:
+
+| State | Meaning |
+|---|---|
+| `VERIFIED` | conformance passed under this profile, current `envHash` |
+| `PROVISIONAL` | bound with explicit operator override, suite not yet passed — **visible in every proposal until cleared** |
+| `STALE` | passed under a different `envHash` |
+| `FAILED` | cannot be bound |
+
+`PROVISIONAL` exists because a bootstrap needs it. It must be loud, it must appear in CI output, and it must never quietly become the steady state.
+
+---
+
+## 7. Supply chain and capability
+
+Dynamic dependency addition is a security surface. Justified Capability Attestation applies unchanged.
+
+- a provider declares its capability requests with justifications; **the grant is policy's decision, never the provider's**
+- negotiation performs **no network access** without an explicit grant. Offline negotiation against cached probes and locked registries is the default, and it is also what makes negotiation a pure function.
+- new transitive dependencies surface in the proposal as a **diff of the resolved tree**, not as a count. "Adds one package" that pulls two hundred transitively is the lie this prevents.
+- provider identity is content-addressed. A provider whose hash changes without a binding change is a halt.
+- the proposal is the review artifact. **It is designed to be read before approval by a human who is tired**, which is the only realistic review condition.
+
+---
+
+## 8. The bootstrap floor
+
+The negotiation engine has dependencies. That is the paradox, and it needs a stated floor.
+
+**Irreducible core, fixed, never negotiated:** a Rust toolchain, one package manager per ecosystem in use, and a filesystem. Nothing else.
+
+Everything above that floor is a provider. The engine itself must be buildable and runnable with zero negotiated dependencies, or the first `init` cannot run. This is a hard constraint on the engine's own implementation and it should be checked in CI: **build the engine with the network off and an empty cache.**
+
+---
+
+## 9. Normative amendments
+
+Apply these to the existing set. Until applied, the docs disagree with each other and this file wins.
+
+| Doc | Amendment |
+|---|---|
+| `ARCHITECTURE.md` | **I3′ replaces I3:** "The harness owns no stack opinion. It must never name a concrete framework, renderer, or runner outside the binding lock." |
+| `ARCHITECTURE.md` | **New I7:** "One mutation path. All state change flows through plan/apply with a journal." |
+| `UX-STACK.md` | Add status header: **"Resolved binding snapshot for profile `linux/wayland/chromium/dev`. Evidence-backed, not axiomatic. Names in this document appear in the binding lock and nowhere else in the system."** |
+| `TESTING.md §3` | Generalise: the substrate conformance suite is one instance of a per-requirement pattern. Every requirement carries a suite; the suite is the provider acceptance gate (§6). |
+| `TESTING.md §7` | Add CI stage: **offline bootstrap** — build the engine with network off and empty cache (§8). |
+| `TESTING.md §2` | Add property class: negotiation is pure and deterministic; apply satisfies P-conv, P-noop, P-resume. |
+| `DECISIONS.md` | **D4 reclassified** from decision to binding, resolved by conformance evidence, changeable by refactor procedure. |
+| `DECISIONS.md` | **D1 reframed**, not resolved: three providers, one suite, empirical gate. Still blocking. |
+| `SPINE.md §3` | Document set gains `vitrine.stack.lock` (binding lock, token space, git-tracked) and `procedures/*.toml`. |
+
+---
+
+## 10. Open
+
+- **P1 — Is this justified at project scale?** Terraform-grade provisioning machinery for a solo tool is plausibly the most over-engineered thing in the doc set. The counter-argument: without it, `UX-STACK.md` is a set of welds, and the stated philosophy is implementation-agnostic-until-inconvenient. The honest question is whether "inconvenient" arrived already and I am building for a portability need that never materialises. **This is the one to argue first.**
+- **P2 — Requirement granularity.** Too coarse ("a frontend") and providers are unswappable monoliths. Too fine ("a way to hash a string") and every dependency needs an adapter and the project dies of interfaces. No principle currently distinguishes them. Suspicion: a requirement is only worth declaring where a *conformance suite* is worth writing — which is a nice test and possibly circular.
+- **P3 — Does purity survive contact with npm?** Negotiation is pure only while probes are cached and no resolution happens during it. The moment a version range must be resolved to satisfy a proposal, purity is gone and F6 is knocking. Possibly requires that providers pin exact versions and never ranges, which pushes work onto provider authors.
+- **P4 — Cross-ecosystem locks.** Rust and Node have separate locks with separate semantics. Does the binding lock reference them, contain them, or generate them? Referencing is cheapest and leaves two sources of truth.
+- **P5 — `PROVISIONAL` decay.** It is designed to be loud, but nothing forces it to clear. An expiry that fails CI after N days is honest and will be hated on the day it fires. Alternative is that `PROVISIONAL` quietly becomes permanent, which is the outcome the state was invented to prevent.
+
+---
+
+## Sign-off
+
+This document is not in effect until the operator approves §9's amendments. Until then the existing docs stand as written and this file is a proposal.
+
+- [ ] §1 review findings accepted (F1–F6)
+- [ ] §9 amendments applied to the doc set
+- [ ] P1 argued — scale justification
+- [ ] `DECISIONS.md` register updated

--- a/docs/testing-harness/README.md
+++ b/docs/testing-harness/README.md
@@ -1,0 +1,107 @@
+# VITRINE
+
+**A canvas-first workbench where a web component is specified, rendered, exercised, measured, and attested — from one manifest.**
+
+> **Status: DESIGN (VITRINE runtime). zenOS adopts this as the default testing harness *reference*; hydrate + tokens + CI alignment ship in-repo. See [ZENOS_INTEGRATION.md](ZENOS_INTEGRATION.md).**
+> Codename is a placeholder — a *vitrine* is a glass display case for specimens. Rename at will.
+
+---
+
+## The one-paragraph version
+
+Component development is three disconnected surfaces: an isolation viewer that knows props, a test runner that knows assertions, and a status document that knows fiction. VITRINE collapses them onto one artifact — the **Card** — so that what you look at, what you assert on, and what you report cannot diverge. Progress stops being self-reported and becomes derived from evidence. The primary view is a spatial canvas rather than a sidebar tree, because concept validation means seeing twelve variants at three widths at once, not one specimen at a time.
+
+---
+
+## Read in this order
+
+| Doc | What it settles |
+|---|---|
+| **[HOUSE_RULES](HOUSE_RULES.md)** | **zenOS normative rules — agents start here** |
+| **[ZENOS_INTEGRATION](ZENOS_INTEGRATION.md)** | How this reference binds to zenOS code and CI |
+| **[VISION](VISION.md)** | Problem, thesis, the three lenses, maturity ladder, non-goals, kill criteria |
+| **[SPINE](SPINE.md)** | Card vs specimen, identity, the document set, resolution pipeline, ledger addressing |
+| **[ARCHITECTURE](ARCHITECTURE.md)** | Invariants, layer map, ingest, canvas model, orchestrator, build topology |
+| **[UX-STACK](UX-STACK.md)** | GMod × FabFilter interaction model, disclosure ladder, render planes, stack choices |
+| **[TESTING](TESTING.md)** | The harness that must exist before implementation |
+| **[PROVISIONING](PROVISIONING.md)** | Stack negotiation, idempotent init, refactor procedures — **PROPOSED, not in effect** |
+| **[GLOSSARY](GLOSSARY.md)** | Pinned vocabulary |
+| **[DECISIONS](DECISIONS.md)** | Every open question, consolidated, in dependency order |
+
+`SPINE` supersedes `ARCHITECTURE §2` and corrects two errors in it. `UX-STACK` pressurises `ARCHITECTURE`'s D1 and says so. `PROVISIONING` proposes amendments to four docs and **does not apply them until signed** — so `ARCHITECTURE` and `TESTING` still carry framings `PROVISIONING` argues against. That disagreement is tracked in `DECISIONS`, not drift.
+
+---
+
+## Invariants
+
+Every decision in every doc is scored against these.
+
+| | |
+|---|---|
+| **I1** | **Single spine.** The Card is the only source of specimen truth. |
+| **I2** | **No hardcoded values.** Literals live in `tokens/` and nowhere else. |
+| **I3** | **The harness owns no rendering opinion.** It must never import a component framework. |
+| **I4** | **Evidence over assertion.** Status is derived, with provenance. No writable status field exists. |
+| **I5** | **Degrades to static.** Every mode survives `build` → `file://`. |
+| **I6** | **Deny by default.** Specimens get no ambient capability unless requested and granted. |
+
+---
+
+## Current state
+
+**Twenty-two open decisions. One blocking. Five settleable without writing code.**
+
+Blocking: **D1, the isolation substrate.** Shadow roots are fast and lie about responsive behaviour; iframes are honest and may be untenable under a continuously animating world transform. The spine is deliberately designed to survive either answer — cards declare *traits*, policy maps traits to *strategy*, and when D1 lands exactly one file changes.
+
+Do these before anything else, in this order:
+
+- [ ] **Survey CEM coverage in real published packages** (O2). If Custom Elements Manifests carry tag names and attribute types but not states, port schemas or traits, then "zero-config adoption" is a hollow claim and VISION's success criteria need rewording. Cheap. An afternoon. Most likely assumption to be wrong.
+- [ ] **Call V3** — is GAUNTLET in v1, or is v1 BENCH + CANVAS + derived rungs with the runner deferred?
+- [ ] **Call S5** — is the native engine real, or does wgpu-in-a-browser earn it later or never?
+- [ ] **Argue O1** — minted identity in a lockfile, or accept that renames nuke baselines?
+- [ ] **Argue P1** — is negotiated provisioning justified at this scale, or is it Terraform for a solo tool? Gates all of `PROVISIONING`.
+
+Then: the D1 spike, against the conformance suite already specified in `TESTING §3`. Throwaway code, hard gate, kill criterion evaluated there.
+
+---
+
+## Known open sores
+
+Stated plainly so they are not rediscovered as surprises.
+
+- **D1 is unresolved and the sandbox model makes it worse.** See `UX-STACK §7`. Three options, none clean, one needs a written exception to the same-substrate rule.
+- **Zero-config adoption is unverified.** See O2 above.
+- **Axis expansion blowup is unspecified.** Four states across five viewports, two themes and two densities is eighty specimens per component. Nothing currently bounds this.
+- **Fixtures are an unconstrained escape hatch.** "Cards are pure data" holds only while fixtures stay small; nothing enforces that yet.
+- **Scope is three products in a trenchcoat.** Isolation viewer, spatial canvas, test runner. V3 exists to cut this down.
+- **Tauri is off the table for Linux for now** — WebKitGTK's frame rates and DMABuf failures are incompatible with the motion premise. Browser-first, revisit when CEF or a Servo webview lands.
+- **Astro may be reduced to a shell server.** Explicit checkpoint at v0.3. No sunk cost.
+
+---
+
+## Non-goals
+
+Not a component library. Not framework-agnostic-by-adapter — custom elements are the contract. Not a design tool and never a Figma round-trip. No cloud, no account, no telemetry, no phone-home, ever. Not a docs site generator. No visual card editor in v1 — cards are authored as code and reviewed as code.
+
+---
+
+## Shape, once it exists
+
+```
+vitrine.toml            project policy
+vitrine.lock            minted identities            [SCRIBE-written]
+tokens/                 scalars — the only literals in the system
+axes/                   viewport, theme, density, locale, motion
+policy/                 capabilities, budgets, a11y, substrate
+fixtures/               impure values, referenced by id
+concepts/               canvas layouts, keyed by SpecimenId
+ledger/                 append-only evidence
+crates/                 core-scene, core-render, core-interact, core-card, core-ledger
+packages/chrome/        VITRINE's own components — dogfooded specimens
+```
+
+---
+
+## Contributing to the design
+
+Roast the docs, not the code — there is no code. Every doc ends with a numbered open-questions section; argue there. A decision is only closed when its entry in `docs/DECISIONS.md` moves, and entries carry their live objections with them so that "resolved" never quietly means "forgotten".

--- a/docs/testing-harness/SPINE.md
+++ b/docs/testing-harness/SPINE.md
@@ -1,0 +1,235 @@
+# VITRINE — SPINE.md
+
+> The manifest layer everything else hangs off. Supersedes `ARCHITECTURE.md §2`.
+> Status: **v0.1 DRAFT — unroasted**. Resolves D3, D6. Deliberately does **not** resolve D1.
+
+---
+
+## 0. Two corrections to `ARCHITECTURE.md`
+
+Owning these before building on them.
+
+**C1 — I conflated card and specimen.** `ARCHITECTURE.md §2` declares `SpecimenCard { id: SpecimenId }`, which is wrong. A card declares a *family*; a specimen is one *point* in that family's space. Evidence, baselines, layout and wires all attach to points, not families. Authorship happens at the family. Getting this backwards would have put per-viewport evidence on a card with no place to live.
+
+**C2 — `placement` does not belong in the card.** I had `placement?: PlacementRef` on the card. A specimen can appear on many canvases in different arrangements; placement is a property of a *concept*, keyed by specimen. Layout moves out of the spine entirely.
+
+---
+
+## 1. The core distinction
+
+```
+CARD  (family, authored)         "button, in these 4 states, with this contract"
+  ×
+AXES  (dimensions, referenced)   viewport × theme × density × motion
+  ↓  expand
+SPECIMEN (point, derived)        "button / disabled / viewport.sm / theme.dark / …"
+```
+
+**Everything downstream addresses specimens. Everything upstream authors cards.** The expansion is the only place the two meet, and it is pure and deterministic.
+
+One consequence worth stating plainly: you cannot add a specimen by hand. Specimens exist because a card declared a state and an axis set contained a member. That *is* invariant I1 — mechanically, not aspirationally.
+
+---
+
+## 2. Identity
+
+The D6 trap: content-addressed ids are stable across moves but detonate baselines on rename; human ids are stable but collide and require discipline. Both are wrong because both make *identity* a function of *naming*.
+
+**Answer: mint opaque ids once, treat names as labels.**
+
+```
+CardId      ULID, minted on first discovery, recorded in vitrine.lock
+StateId     ULID, minted on first discovery, recorded in vitrine.lock
+AxisMemberId  authored (axes are hand-declared, ids are explicit)
+
+Locator     { package, element, cardName }   derived, mutable, never load-bearing
+SpecimenId  = hash(CardId, StateId, canonical(AxisVector))   deterministic
+```
+
+Renaming a card, a state, a file, or a package changes **nothing**. Deleting breaks things, which is correct.
+
+**Rebinding.** When SCRIBE sees a state vanish and an unfamiliar one appear in the same card, it proposes a rebind and **stops**. Never silent, never heuristic-only — a wrong rebind silently poisons visual baseline history, which is worse than losing them. The confirmed rebind is recorded in the lock with provenance and timestamp.
+
+`vitrine.lock` is git-tracked, human-diffable, and the single mutable thing SCRIBE writes to the spine.
+
+---
+
+## 3. The document set
+
+Nine kinds of document. Each has exactly one job. Literals live in exactly one of them.
+
+```
+vitrine.toml           project policy: roots, resolver config, schema version
+vitrine.lock           minted identities + rebind history   [SCRIBE-written]
+
+tokens/*.toml          scalars. THE ONLY PLACE A LITERAL MAY EXIST.
+axes/*.toml            axis sets: viewport, theme, density, locale, motion
+policy/
+  capabilities.toml    grants (Tier A/B) — card requests, policy grants
+  budgets.toml         perf budgets
+  a11y.toml            rule sets + contrast policy
+  substrate.toml       traits → mount strategy      ← D1 LANDS HERE, ONLY HERE
+fixtures/*.ts          impure/live values, referenced by id
+**/*.card.ts           card overlays, colocated with components
+concepts/*.json        canvas layouts, keyed by SpecimenId
+ledger/*.jsonl         append-only evidence
+```
+
+`768` appears once, in `tokens/`, as `viewport.sm.width`. `axes/viewport.toml` references it. A card references the axis. Nothing else has an opinion. That is I2, enforced by there being nowhere else to put it.
+
+---
+
+## 4. The card
+
+```ts
+// NORMATIVE CONTRACT SKETCH — shapes only, no impl
+interface Card {
+  schemaVersion: SemVer;
+  id?: CardId;              // omitted → minted into the lock on first sight
+  element: TagName;
+  source: ModuleRef;
+
+  states: State[];          // named configurations
+  axes: AxisRef[];          // which dimensions this card is expanded across
+
+  ports: {                  // wire endpoints — see §6
+    out: OutPort[];
+    in:  InPort[];
+  };
+
+  contract: {
+    a11y?:    PolicyRef;
+    budgets?: PolicyRef;
+    invariants?: InvariantRef[];
+  };
+
+  capabilities?: CapabilityRequest[];   // REQUESTS. Grants live in policy.
+  traits?: Traits;                      // FACTS, not strategies — see §5
+}
+
+interface State {
+  id?: StateId;             // omitted → minted
+  name: string;             // label only, freely renameable
+  props?:  Record<PropName, Value | FixtureRef>;
+  attrs?:  Record<AttrName, Value | FixtureRef>;
+  slots?:  Record<SlotName, MarkupRef | FixtureRef>;
+  context?: Record<ContextKey, FixtureRef>;
+  preconditions?: InteractionScriptRef[];   // "open the menu first"
+}
+
+type Value = TokenRef | Primitive;   // Primitive permitted ONLY where the
+                                     // resolver proves no token could apply
+```
+
+**Cards are pure data.** `*.card.ts` is a *builder* evaluated at build/dev time that emits a plain document. No functions survive into the registry — the Rust core consumes it, and the static build serialises it (I5). Anything that must be live is a `FixtureRef`, resolved by the substrate at mount.
+
+That constraint is load-bearing, not stylistic. The moment a card can contain a closure, the static build dies and the wasm boundary needs a JS callback channel.
+
+---
+
+## 5. Traits, not strategies — how the spine survives D1
+
+The temptation is a card field like `mount: "iframe" | "shadow"`. That would weld the unresolved substrate decision into every card ever authored.
+
+**Cards declare facts about the component. Policy maps facts to strategies.**
+
+```ts
+interface Traits {
+  ownMediaQueries?: boolean;   // component ships its own @media
+  statefulMount?:   boolean;   // rebuilding internal state is expensive
+  heavyInit?:       boolean;   // first paint is costly
+  globalSideEffects?: boolean; // touches document/window on connect
+}
+```
+
+`policy/substrate.toml` maps trait combinations to mount strategy, LOD behaviour, and unmount-vs-freeze. When D1 resolves, **one file changes** and no card is touched. If D1 resolves differently for SANDBOX than for GAUNTLET, that's two profiles in one file — still no card churn.
+
+This is the mechanism that makes "design the spine before D1" legitimate rather than reckless.
+
+---
+
+## 6. Ports and wire validity
+
+Wires are `out.event → in.prop`. Validity needs structure, not names.
+
+```ts
+interface OutPort { event: EventName;  detail: SchemaRef; when?: TriggerNote; }
+interface InPort  { prop:  PropName;   accepts: SchemaRef; }
+```
+
+Connection is legal iff `resolver.isAssignable(out.detail, in.accepts)`. The spine holds **references**, never schemas — whether they're JSON Schema, TS-derived, or something else is the resolver's business. Swapping schema systems must not touch a card.
+
+CEM gives you event *names* and attribute types; it is thin on `detail` shapes. Expect the overlay to carry most port typing in practice — see §9, O2.
+
+---
+
+## 7. Resolution pipeline
+
+Pure, staged, cacheable. Each stage's output is a function of its inputs only.
+
+```
+  discover ──▶ skeleton ──▶ overlay ──▶ resolve ──▶ expand ──▶ REGISTRY
+     │            │            │           │          │
+   CEM +       cards with   card.ts     tokens+     × axes
+   globs       minted ids   merged      policy     = specimens
+```
+
+**Provenance is mandatory.** Resolving a value returns:
+
+```ts
+interface Resolved<T> { value: T; provenance: { layer: LayerId; key: string }[]; }
+```
+
+So the UI can answer *"why is this viewport 768?"* with the full chain — project default → package policy → card override. Config carries evidence too (I4). This is the same discipline as the ledger, applied one layer down, and it costs almost nothing if built in from the start and is agony to retrofit.
+
+**Invalidation is scoped by stage.** Token change → re-resolve + re-expand, skip discovery. Card change → one card's overlay onward. CEM change → that package's skeleton onward. A token edit must never blow the whole registry; at realistic scale that's the difference between instant and unusable HMR.
+
+---
+
+## 8. What the ledger addresses
+
+```ts
+interface EvidenceRecord {
+  specimenId: SpecimenId;      // the point, not the family
+  checkId: CheckId;
+  verdict: Pass | Fail | Skip;
+  artefactRef?: ArtefactRef;   // screenshot, trace, axe result
+  envHash: Hash;               // determinism envelope + token snapshot + substrate version
+  toolVersion: SemVer;
+  at: Timestamp;
+  signer?: SignerRef;          // rung 6 only
+}
+```
+
+**Rung folding:**
+- specimen rung = highest rung whose checks all pass with a current `envHash`
+- **card rung = min over its specimens**
+
+The min-fold is the honest rule and will be unpopular: a button that fails contrast at `theme.dark` is not `ACCESSIBLE`, it is a button with a contrast bug. Averaging would produce a comfortable number and a false one.
+
+Evidence from a stale `envHash` is **stale, not failed** — displayed differently, never silently trusted, never counted as a pass.
+
+---
+
+## 9. Open for roast
+
+- **O1 — Minted ids in a lockfile.** Buys rename-safety, costs a SCRIBE write path, a merge-conflict surface, and a rebind ritual. Alternative: accept that renames nuke baselines and tell people not to rename. Cheaper, and arguably fine for a solo operator. Am I building multiplayer infrastructure for a single-player game?
+- **O2 — CEM's real weight.** VISION promises zero-config adoption. If CEM carries tag names and attribute types but the overlay carries all states, port detail schemas, traits, and fixtures, then "zero-config" gets you an empty card and a `DECLARED` rung. That may be an honest floor or a hollow claim. **Survey real published packages before this ships** — this is the assumption most likely to be wrong.
+- **O3 — Axis expansion blowup.** 4 states × 5 viewports × 2 themes × 2 densities = 80 specimens *per component*. Evidence, baselines and canvas cost all scale with that product. Options: sparse axes declared per-state, sampling policy, or expansion on demand with cached rungs. Currently unspecified and it will bite in week two.
+- **O4 — Fixtures are an escape hatch.** "Cards are pure data" is only true if fixtures stay small. Nothing currently stops a fixture from becoming the actual configuration, at which point purity is theatre and the static build breaks. Needs a constraint I haven't written.
+- **O5 — Provenance on every resolved value.** Correct, and possibly expensive per frame if resolution happens in the hot path. Probably wants resolve-once-cache-hard, but then session overrides need to invalidate precisely.
+
+---
+
+## 10. Build order
+
+The spine is buildable now — D1 does not block it (§5).
+
+1. tokens + axes + resolver with provenance — no cards yet, prove I2 in isolation
+2. lock + identity minting + rebind proposal
+3. card schema + `*.card.ts` builder → plain document
+4. CEM ingest → skeleton (**do O2's survey first**)
+5. expansion → registry, serialisable
+6. ledger addressing + rung fold
+
+Nothing above touches the substrate, the canvas, or a renderer. If any step needs to know how a specimen mounts, the spine has been designed wrong and it's a stop-work.

--- a/docs/testing-harness/TESTING.md
+++ b/docs/testing-harness/TESTING.md
@@ -1,0 +1,143 @@
+# VITRINE — TESTING.md
+
+> The harness that must exist before implementation does.
+> Status: **v0.1 DRAFT — unroasted**. Partially blocked by D1 and D4; §2–§5 are not.
+
+---
+
+## 0. The recursion, named
+
+VITRINE is a test harness. Its own tests are therefore in constant danger of becoming a second, worse test harness that duplicates the first.
+
+**The rule that prevents this:**
+
+> VITRINE's own components are tested *by VITRINE*, through the public spine, once VITRINE can render anything at all. Everything below the spine is tested conventionally and never sees a browser.
+
+Concretely: `core-*` crates are Rust unit and property tests. The resolver is a pure-function test suite. VITRINE's own chrome — the tool strip, the disclosure surfaces, the port pips — are custom elements with cards in `packages/chrome/`, and they are dogfooded specimens. If the chrome cannot be expressed as cards, the card model is inadequate and that is a finding, not an inconvenience.
+
+**Bootstrap order matters:** the spine's tests must pass before any chrome exists, because the chrome's tests depend on the spine working.
+
+---
+
+## 1. Layers
+
+| Layer | Kind | Runs where | Needs D1? |
+|---|---|---|---|
+| Tokens / axes / resolver | pure unit + property | Rust, no DOM | no |
+| Identity + lock | unit + scenario | Rust, temp fs | no |
+| Card parse + merge | golden-file | Rust | no |
+| Expansion | property | Rust | no |
+| Ledger + rung fold | property | Rust | no |
+| Interaction model | deterministic simulation | Rust, headless | no |
+| Substrate contract | conformance suite | browser | **yes** |
+| Chrome components | dogfooded specimens | VITRINE | yes |
+| End-to-end lens behaviour | e2e | browser | yes |
+
+Six of nine layers are D1-independent and buildable now. This is the argument for writing tests before the substrate question is settled — most of the surface does not touch it.
+
+---
+
+## 2. Properties, not examples
+
+The spine is a set of pure transformations. Example-based tests will miss the interesting failures. Properties worth stating as executable invariants:
+
+**Resolver**
+- resolution is deterministic: same inputs, same output, always
+- resolution is monotone in override strength — a stronger layer never loses to a weaker one
+- every resolved value carries a non-empty provenance chain
+- **no primitive escapes the resolver without either a token reference or a resolver-proven exemption** (this is I2, executable)
+
+**Identity**
+- renaming any card, state, file or package leaves every `SpecimenId` unchanged
+- deleting a state and adding an unrelated one produces a rebind *proposal* and never a silent rebind
+- `SpecimenId` is a pure function of its inputs and independent of axis-member ordering
+
+**Expansion**
+- `|specimens| == |states| × ∏|axis members|`, exactly, no dedup surprises
+- expansion is order-independent and idempotent
+- every specimen traces back to exactly one card and one state
+
+**Ledger**
+- fold is monotone: adding a passing record never lowers a rung
+- adding a failing record never raises one
+- card rung equals the minimum over its specimens (`SPINE.md §8`)
+- a stale `envHash` never counts as a pass, and is distinguishable from a fail
+- rung six decays when any lower-rung evidence is invalidated — **human sign-off never outranks a failing test**
+
+That last property is the one worth writing first. It is the entire honesty claim, expressed as an assertion.
+
+---
+
+## 3. The substrate conformance suite
+
+D1's answer is not yet known. **The suite that judges it can be written now**, and writing it is how D1 gets decided rather than argued.
+
+Any substrate must pass, identically:
+
+- mount and teardown leave no residue in the host document
+- forced viewport width is honoured by the component's own `@media` queries
+- injected determinism holds: seeded RNG, frozen clock, pinned locale and timezone, `prefers-*` overrides
+- declared events reach the tap with intact detail and composed path
+- undeclared capability use is recorded, not silently swallowed
+- HMR re-mount preserves scroll position and, where possible, interaction state
+- style isolation: host styles do not leak in, specimen styles do not leak out
+- **N specimens remain interactive at 120fps under continuous world transform** — N from tokens, not a literal
+
+The last one is the gate `UX-STACK.md §7` demanded. Options (a), (b) and (c) each run this suite; the results decide, and the suite outlives the decision as a regression net.
+
+---
+
+## 4. Interaction, tested without a browser
+
+`core-interact` is a state machine plus a spring integrator. Both are deterministic and both can be tested headlessly at a fixed timestep — which matters, because interaction bugs found by clicking are found late and reproduced never.
+
+- gesture → intent mapping is total: every (input, modifier, tool mode) triple maps somewhere, including explicit no-ops
+- disclosure levels are interruptible: L1→L3 mid-flight retargets, never queues
+- the spring is critically damped for the token-declared constants and never overshoots past tolerance
+- **the disclosure superset law is executable:** for every entity, the set of visible affordances at level N is a superset of level N−1, and the position of every shared affordance is identical across levels
+
+That last check is worth more than any amount of design review. It turns `UX-STACK.md §5`'s law from a promise into a failing test.
+
+---
+
+## 5. Golden files and what they cost
+
+Card parse, merge and expansion are golden-file tested: fixture inputs, committed expected outputs, diff on change.
+
+Cheap, high-coverage, and quietly corrosive — golden files get regenerated when they fail, and a regenerated golden is a test that has stopped testing. Mitigation: goldens are small and hand-written, regeneration is a separate explicit command that is never part of the normal loop, and a regenerated golden must be reviewed as a diff.
+
+Visual baselines are **not** golden files and are not committed as truth. They are ledger artefacts with an `envHash`, and they are stale rather than wrong when the environment moves.
+
+---
+
+## 6. What is deliberately not tested
+
+- **wgpu output pixels.** Shader correctness is judged by eye and by the frame budget. Pixel-comparing GPU output across drivers is a full-time job that produces flakes and no information.
+- **Astro's rendering.** Framework behaviour is the framework's problem.
+- **The canvas transform maths beyond its invariants.** Round-trip world↔viewport and camera-matrix agreement between the DOM and GPU planes are tested; specific pan and zoom sequences are not.
+- **Third-party components under test.** VITRINE tests that its harness is honest about them, not that they are correct.
+
+---
+
+## 7. CI shape
+
+| Stage | Gate | Runs |
+|---|---|---|
+| Rust unit + property | must pass | every push |
+| Golden files | must pass, no auto-regen | every push |
+| Interaction simulation | must pass | every push |
+| Substrate conformance | must pass | every push, once D1 lands |
+| Perf gate | budget from tokens | every push, once D1 lands |
+| Dogfood specimens | rung must not regress | every push |
+| Static build | must produce a `file://`-openable bundle | every push — this is I5, and it will rot silently otherwise |
+
+**The dogfood gate is the interesting one.** CI computes VITRINE's own component rungs from the ledger and fails if any card drops. The project's honesty claim is enforced against the project itself, which is either elegant or insufferable depending on the week.
+
+---
+
+## 8. Open
+
+- **T1.** Does the dogfood gate deadlock at the start? Chrome components cannot be dogfooded until VITRINE renders, and VITRINE needs chrome to render. Probable answer: a minimal chrome bootstrap that is exempt and stays exempt, which is an exemption list that will grow if unwatched.
+- **T2.** Property tests need a card generator. Writing a generator that produces *valid* cards means encoding the schema twice — once as the schema, once as the generator. Is a constrained generator over real fixtures enough?
+- **T3.** The perf gate's N (§3) is a token, so it can be lowered when it fails. That is exactly how perf gates die. Should N be a token at all, or is this the one place a committed literal is correct?
+- **T4.** Blocked on D4: whether the conformance suite runs under the same runner as everything else, or is its own thing.

--- a/docs/testing-harness/UX-STACK.md
+++ b/docs/testing-harness/UX-STACK.md
@@ -1,0 +1,188 @@
+# VITRINE — UX-STACK.md
+
+> Stack decision record + interaction architecture for the **SANDBOX** layer.
+> Supersedes nothing in `ARCHITECTURE.md`; it *pressurises* D1 badly (see §7).
+> Status: **v0.1 DRAFT — unroasted**. Versions verified 2026-07-25.
+
+---
+
+## 1. The hard constraint, up front
+
+**You cannot render live web components inside a Vulkan swapchain.** Not with a trick, not with a shim. A custom element is a DOM node in a browser engine's layout tree; Vulkan is a triangle pipe. There is no bridge that preserves inspection, the a11y tree, text selection, or interaction.
+
+So the ambition splits into two products, and you must know which one is load-bearing:
+
+| | Web component sandbox | Native engine |
+|---|---|---|
+| Specimens | live DOM, inspectable | not possible |
+| Chrome/panels | DOM + CSS | immediate-mode or custom |
+| World layer | GPU | GPU |
+| Runs on | Chromium / Wayland | Vulkan direct |
+
+**Recommendation: keep them one codebase and two presentations.** Shared Rust core, forked render target. Same pattern as the keyboard IME — core + shims — which is why it'll feel right.
+
+The move that makes this cheap is **wgpu**: one crate, one WGSL shader set, that runs natively on Vulkan/Metal/D3D12/GL *and* over WebGPU/WebGL2 in wasm. Write the world renderer once in Rust. Today it's a `<canvas>` in Chromium. Later it's a Vulkan surface via winit. **The renderer never gets rewritten.** That single fact is the spine of this whole recommendation.
+
+---
+
+## 2. The second hard truth: not Tauri on Linux. Not yet.
+
+Tauri on Linux renders through WebKitGTK, and WebKitGTK is documented-bad for exactly the workload here:
+
+- DMABuf framebuffer construction failures; blank/flickering windows, worst on NVIDIA
+- WebGL renderer string masked for fingerprinting — you cannot even tell what's behind the context
+- Tauri's own docs describe high input latency and low frame rates in WebGL-heavy views; community reports of ~40fps where Chromium hits 240
+- Tauri maintainers have said they can't fully recommend Tauri for Linux; GTK4 and CEF work has started, plus a Servo-based webview with Igalia — none shipped
+
+FabFilter feel is **120fps interruptible spring motion under a continuous drag**. WebKitGTK will not give you that on Omarchy. Shipping Tauri here would be choosing the pretty architecture diagram over the actual product.
+
+**Ship v1 as a browser app.** Chromium on Wayland, Vulkan-backed WebGPU, full modern CSS, zero packaging, instant HMR. Revisit Tauri when CEF or Verso lands — the app stays portable because the Rust core doesn't care.
+
+---
+
+## 3. Stack
+
+### Rust core — one cargo workspace, two targets
+
+| Crate | Job | wasm | native |
+|---|---|---|---|
+| `core-scene` | entities, transforms, spatial index (bevy_ecs standalone, not full Bevy) | ✓ | ✓ |
+| `core-render` | **wgpu 30** + WGSL: wires, gizmos, auras, analyzers, grid | → WebGPU | → Vulkan |
+| `core-interact` | tool state machine, disclosure ladder, gesture→intent, spring integrator | ✓ | ✓ |
+| `core-card` | specimen card resolution, token/policy chain | ✓ | ✓ |
+| `core-ledger` | evidence, attestation, rungs | ✓ | ✓ |
+
+Boundary is a **command/event protocol**, not direct wasm-bindgen calls. Same protocol later rides IPC to a native process. Costs a serialisation layer, buys the entire phase-3 story.
+
+### Web shell — today
+
+- **Astro 7** (7.0.9). Astro 6 moved the dev server onto Vite's Environment API, so dev and prod finally share one path — relevant because the harness *is* a dev server. Static chrome, routing, content collections as the card registry.
+- **React 19** (19.2.x) — **panels and chrome only.** Formally banned from the interaction hot path (§5).
+- **Vite** — HMR, wasm plugin, glob discovery.
+- **CSS, the parts that actually earn their place:**
+  - `@property` — animatable custom properties. This is what lets disclosure transitions run on the compositor with zero JS. Load-bearing, not decoration.
+  - OKLCH + `color-mix()` — token-driven theming that stays APCA-checkable
+  - container queries — specimen responsive testing without the D1 iframe tax, *where components opt in*
+  - CSS anchor positioning + `popover` — disclosure surfaces tethered to world-space entities (Chromium-first; acceptable, we're Chromium-first anyway)
+  - `content-visibility` / `contain` — canvas virtualisation assist
+  - View Transitions — mode switching without a hard cut
+
+### Native runtime — later
+
+`winit` + `wgpu 30` → Vulkan. `core-render` unchanged.
+
+**Bevy (0.19, June 2026)** is the alternative: you'd get ECS, asset pipeline, and an editor preview that landed in 0.18. Verdict: **use `bevy_ecs` standalone now, not the engine.** Full Bevy brings a UI layer (Feathers) you will never use because your UI is DOM, and its scene format is still code-driven with no asset loader. Take the ECS, leave the engine, keep the door open.
+
+---
+
+## 4. GMod × FabFilter, decomposed
+
+Both refuse to leave the world. That's the whole thesis, and it's the same thesis twice.
+
+**FabFilter's actual primitives:**
+1. The display *is* the control — param space and screen space are one bijective projection, not "chart with sliders underneath"
+2. Live measurement overlaid in the same coordinate space as the control — cause and effect in one glance
+3. Disclosure by proximity and intent, rendered *at* the thing, never in a far-away panel
+4. Modifier-graded precision — same gesture, different resolution
+5. Interruptible spring motion — you can grab something mid-animation
+6. Expert view is a **superset** of basic view *in the same spatial arrangement*
+7. No modals, no confirmations; undo is the safety net
+
+**GMod's primitives:**
+1. Spawn menu — held-key palette over the world, never a mode change
+2. Tool gun — one tool, N modes; the mode decides what a click *means*; mode owns a small HUD, not a sidebar
+3. Physgun — direct grab with distance/rotation modifiers (this is FabFilter #4 wearing a hat)
+4. Wiremod — node graph in **world space**, not a separate editor
+5. Hold-C context menu — entity properties in place
+6. Everything is an entity of a class, inspectable at runtime
+
+### The mapping
+
+| GMod | VITRINE |
+|---|---|
+| entity | specimen |
+| spawn menu | component registry as held-key radial palette |
+| tool gun modes | `PLACE / GRAB / WIRE / PROBE / MEASURE / ATTEST` |
+| physgun | direct manipulation with modifier-graded precision |
+| wiremod | **`component.event → component.prop`, drawn as live wire** |
+| hold-C properties | L2/L3 inline disclosure |
+| entity class | specimen card |
+
+**The wire idea is the best thing in this design.** VITRINE already taps every `CustomEvent` crossing a specimen boundary (`ARCHITECTURE.md §6`). Render that tap as world geometry and you *watch events fire* — a pulse travels the wire from emitter to consumer. Behavioural truth becomes visible without opening a console. The event tap was already built for the test runner; the sandbox gets it for free. That's I1 (single spine) paying rent a third time.
+
+---
+
+## 5. Progressive disclosure — the ladder
+
+| L | Name | Trigger | Shows |
+|---|---|---|---|
+| L0 | AMBIENT | default | entity + maturity aura only |
+| L1 | PROXIMATE | cursor within radius | handles, name, rung, port stubs |
+| L2 | FOCUSED | selected | gizmo, all ports, inline scalar controls |
+| L3 | EDITING | active drag | live readout, snap guides, modifier hints |
+| L4 | EXPERT | held modifier / pinned | full card, contract, evidence ledger, capability grants |
+
+**The law (non-negotiable, this is what makes it FabFilter and not Storybook):**
+
+> **L4 is a strict superset of L0–L3 in the same spatial arrangement. Nothing that was visible moves when you level up.**
+
+Break this and you've built a tool with two personalities that users must learn twice. Every disclosure level is additive overlay on a fixed layout. This constrains the entity's visual design hard — you must lay out for L4 first and *subtract* down to L0, never the reverse.
+
+Corollaries:
+- Radius, timing, and spring constants come from tokens (I2). No magic numbers.
+- Levels are **interruptible** — L1→L3 mid-flight must retarget, not queue. Requires springs with retargeting, not CSS keyframes. ~60 lines of critically-damped integrator in `core-interact`, no dependency, constants from tokens.
+- Modifier→intent is a **map**, declared once, not `if (e.shiftKey)` scattered across handlers.
+
+---
+
+## 6. Render planes
+
+```
+ z+   DOM overlay      HUD, tool strip, pinned panels     [viewport space, React]
+      DOM world        specimens                          [world transform]
+      GPU world        wires, gizmos, auras, analyzers     [world transform, wgpu]
+ z-   GPU backdrop     grid, ambient, vignette            [world transform, wgpu]
+```
+
+Two planes, one camera. **The camera matrix is owned by `core-scene` and published to both** — neither plane owns it, so they cannot desync. DOM world plane consumes it as a single `matrix3d()` on one containing element.
+
+**React is banned below the overlay plane.** Drag loops write transforms imperatively via refs inside a rAF loop driven by the core. React reconciles panel *structure*; it never sees a pointermove. Non-negotiable at 120fps.
+
+---
+
+## 7. This breaks D1 and I need to say so
+
+`ARCHITECTURE.md` D1 leaned toward **iframe-per-specimen with a recycling pool** — chosen for honest media queries.
+
+The sandbox model makes that considerably worse:
+
+- iframes are expensive to composite; dozens of them under a continuously animating `matrix3d()` will cost you the frame budget the whole design is premised on
+- pointer events across iframe boundaries complicate grab/wire gestures at every step
+- an iframe cannot be perspective-transformed or shader-affected, so it will always sit visually *apart* from the GPU world plane
+
+Honest options:
+- **(a)** Keep iframes, accept that SANDBOX is a low-density mode (tens, not hundreds of specimens) and lean harder on LOD
+- **(b)** Shadow-root specimens, sacrifice real media queries, require container queries from components under test — cheap, fast, and a real capability loss
+- **(c)** Hybrid: shadow-root by default, promote to iframe on focus. Two mount paths, which §8 of `ARCHITECTURE.md` explicitly forbids for the test runner. Would need a written exception.
+
+I don't have a confident answer. **This is the decision to make before anything else gets built**, and the D1 spike (`ARCHITECTURE.md §12 step 1`) should now include "N specimens under continuous world transform at 120fps" as an explicit pass/fail.
+
+---
+
+## 8. Omarchy / Arch notes
+
+- Chromium on Wayland: `--ozone-platform=wayland`, Vulkan-backed WebGPU. Mesa RADV/ANV are fine; NVIDIA proprietary is the usual coin flip.
+- Hyprland tiling means **arbitrary window geometry, always** — no fixed layout may exist anywhere. Conveniently this is just I2 again.
+- Keyboard-first is a gift: hold-key tool modality is already Hyprland muscle memory. Tool switching should be chorded and holdable, never a click target.
+- Dev loop: `vite` + `cargo watch` + `wasm-pack` in three panes. No Node-side build of the Rust; wasm artefact is a Vite dependency.
+- Native later: `vulkan-icd-loader` + vendor ICD, `winit` Wayland backend. No X11 path, don't build one.
+
+---
+
+## 9. Open for roast
+
+- **S1.** Is the browser-first call cowardice or correctness? It costs the native-feel story and filesystem access for a year. Alternative: eat WebKitGTK now and design *down* to what it can do — which probably means abandoning the FabFilter motion premise entirely.
+- **S2.** `bevy_ecs` standalone vs a hand-rolled entity store. ECS for a few hundred entities is arguably ceremony; but it's the thing that makes a future native runtime a port instead of a rewrite.
+- **S3.** Command protocol over the wasm boundary vs direct bindings. Serialisation cost per frame is real. Is phase-3 portability worth paying for it every frame, today?
+- **S4.** §7. The one that matters.
+- **S5.** Is the engine ambition real, or is it the thing that kills the harness by making every decision 3× more expensive for a future that never arrives? Cheapest honest answer: build the sandbox with wgpu, and let the engine earn its existence later or not at all.

--- a/docs/testing-harness/VISION.md
+++ b/docs/testing-harness/VISION.md
@@ -1,0 +1,139 @@
+# VITRINE — VISION.md
+
+> Codename placeholder. A *vitrine* is a glass display case for specimens. Rename at will.
+> Status: **v0.1 DRAFT — unroasted**. No code exists. No code will exist until this is signed off.
+
+---
+
+## 1. One-liner
+
+A sovereign, canvas-first workbench where a web component is **specified, rendered, exercised, measured, and attested** — with the specimen manifest as the single spine feeding dev view, test runner, and progress dashboard alike.
+
+---
+
+## 2. The problem
+
+Component development today is three disconnected surfaces:
+
+| Surface | Tool | What it knows | What it forgets |
+|---|---|---|---|
+| Isolation dev | Storybook | props/args | whether it passes anything |
+| Test | Vitest / Playwright | assertions | what the component looks like |
+| Progress | Jira / a spreadsheet | ticket status | reality |
+
+The gap: **the thing you look at and the thing you assert on are described twice**, by hand, in two vocabularies, and they drift. Then a third human writes a status update that is fiction.
+
+Second gap: **linear story lists are the wrong topology for concept validation.** When you're deciding whether a UI idea holds up, you don't want a sidebar tree and one specimen at a time. You want twelve variants on a surface at once, at different widths, in different themes, in different states, side by side, and you want to drag them around and squint. That's a canvas, not a list.
+
+---
+
+## 3. Thesis / core bet
+
+**One artifact — the Specimen Card — drives everything.**
+
+```
+                 ┌──> canvas render (visual truth)
+Specimen Card ───┼──> test case generation (behavioural truth)
+                 ├──> a11y + contrast gate (accessibility truth)
+                 └──> attestation ledger (progress truth)
+```
+
+If the card is the only place a component's states are declared, then "what we look at", "what we assert", and "what we report" cannot diverge. Progress stops being self-reported and becomes **derived**.
+
+Secondary bet: **native custom elements + Astro is a genuinely zero-runtime harness.** No framework adapter layer, no `@storybook/web-components` shim, no hydration directives. Astro emits static shell HTML; the custom element upgrades itself; Vite provides HMR. The harness owns no rendering opinion whatsoever.
+
+---
+
+## 4. Who it's for
+
+- **P0 — the operator (me).** Solo/small-team component work across projects, offline-capable, no cloud, no telemetry, no account.
+- **P1 — a reviewer.** Someone handed a URL or a static build who needs to judge a UI concept without running a dev server.
+- **P2 — a machine.** Agents that read the manifest, render specimens, diff snapshots, and write attestations without a human in the loop.
+
+Explicitly **not** for: design-system marketing sites, public documentation portals, non-technical stakeholder theatre.
+
+---
+
+## 5. The three modes
+
+One app, one manifest, three lenses over it.
+
+### BENCH — isolate
+Single specimen, full viewport, controls panel, live event log, DOM/shadow inspector, computed-style readout. This is the "I am building the thing" mode. Nothing novel here; it must simply be fast and not lie.
+
+### CANVAS — compose & compare
+Infinite pan/zoom surface. Specimens are **live DOM**, not screenshots. Drop the same component at 320/768/1440 side by side. Drop three variants of a button next to each other. Draw a frame around a set of specimens and call it a *concept*. Annotate. Arrange. The layout is a committed artifact, not local ephemera — **layout is reviewable in a PR**.
+
+This is the differentiating mode and the reason the project exists.
+
+### GAUNTLET — prove
+Every specimen is a test case whether you wrote assertions or not. Baseline gauntlet, free of charge, from the card alone:
+- renders without throwing
+- upgrades as a custom element
+- emits its declared events
+- passes automated a11y rules
+- meets contrast policy
+- matches its visual baseline
+- respects declared perf budget
+
+Author-written interaction assertions layer on top. The gauntlet runs in CI **and** on the canvas — a specimen on the canvas wears its own pass/fail state as a visible aura.
+
+---
+
+## 6. Maturity ladder (the "progress" part)
+
+A specimen's status is **computed from evidence**, never typed by a human.
+
+| Rung | Name | Earned when |
+|---|---|---|
+| 0 | `DECLARED` | card exists, no implementation resolves |
+| 1 | `STUB` | element resolves, renders something |
+| 2 | `RENDERS` | renders without error across all declared viewports |
+| 3 | `BEHAVES` | declared events fire; interaction assertions pass |
+| 4 | `ACCESSIBLE` | a11y rules + contrast policy pass |
+| 5 | `PINNED` | visual baseline captured and stable |
+| 6 | `ATTESTED` | all of the above + human sign-off recorded with provenance |
+
+The canvas rendered at rung-colour = a live kanban of component maturity that **cannot** be gamed by moving a ticket. Component-level progress percentage is arithmetic, not vibes.
+
+---
+
+## 7. Non-goals (hard)
+
+1. **Not a component library.** Ships zero components of its own beyond its own chrome.
+2. **Not framework-agnostic-by-adapter.** Custom elements are the contract. React/Vue/Svelte components are supported exactly to the degree they're wrapped as custom elements. No adapter zoo.
+3. **Not a design tool.** The canvas arranges and annotates live components. It does not draw shapes, does not do vector editing, is not Figma, will never round-trip to Figma.
+4. **No cloud, no account, no telemetry, no analytics, no phone-home.** Ever. The harness runs offline from a folder.
+5. **Not a docs site generator.** A static export exists for review, not for publishing.
+6. **No visual card editor in v1.** Cards are authored as code, reviewed as code.
+
+---
+
+## 8. Success criteria
+
+Ship gate for v1 — all must hold:
+
+- **Adoption cost:** a component with an existing custom-elements manifest appears on the canvas with **zero** hand-written config.
+- **Honesty:** deleting a component's implementation drops its rung within one HMR cycle, visibly, without a rebuild.
+- **Speed:** N specimens on canvas stays interactive at pan/zoom; degradation is graceful (virtualisation/freeze), never a cliff.
+- **Portability:** `build` produces a static bundle that opens from `file://` or any dumb static host, canvas included, no server.
+- **Single-spine proof:** it is impossible to add a specimen state to the canvas that the gauntlet does not see.
+
+## 9. Kill criteria
+
+Abandon or hard-pivot if:
+
+- Isolation cost (whatever substrate wins, see ARCHITECTURE D1) makes a realistic canvas unusable and no virtualisation strategy recovers it.
+- HMR cannot be made to work through the isolation boundary — a harness that requires manual refresh is dead on arrival.
+- Astro's role collapses to "serves an SPA", in which case drop Astro and admit it's a Vite app.
+
+---
+
+## 10. Open for roast
+
+Vision-level only — architecture decisions live in `ARCHITECTURE.md §Open Decisions`.
+
+- **V1.** Is the maturity ladder over-engineered? The honest minimal version is three rungs: `RENDERS` / `BEHAVES` / `PINNED`. Seven rungs may be ceremony that produces a pretty canvas and no information.
+- **V2.** Is "layout as a committed artifact" right, or does canvas layout churn poison every diff and get `.gitignore`'d by week two?
+- **V3.** Should GAUNTLET be in scope for v1 at all, or is v1 "BENCH + CANVAS with an honest maturity ladder" and the test runner is v2? Scope is currently three products in a trenchcoat.
+- **V4.** Is the P2 "agent as user" persona real work now, or is it a manifest-format constraint that costs nothing to honour and everything to build for?

--- a/docs/testing-harness/ZENOS_INTEGRATION.md
+++ b/docs/testing-harness/ZENOS_INTEGRATION.md
@@ -1,0 +1,80 @@
+# zenOS ↔ VITRINE Integration
+
+> How the default testing harness reference connects to zenOS code, CI, and agent onboarding.
+
+---
+
+## Document map
+
+| Path | Role |
+|---|---|
+| [`README.md`](README.md) | VITRINE overview and read order |
+| [`HOUSE_RULES.md`](HOUSE_RULES.md) | zenOS normative rules (start here for agents) |
+| [`TESTING.md`](TESTING.md) | Harness layers, properties, CI shape |
+| [`PROVISIONING.md`](PROVISIONING.md) | Stack negotiation, hydrate handshake |
+| [`SPINE.md`](SPINE.md) | Card/specimen manifest layer |
+| [`DECISIONS.md`](DECISIONS.md) | Open decision register |
+
+---
+
+## Repo layout (zenOS bindings)
+
+```
+docs/testing-harness/     ← VITRINE reference doc set (this directory)
+tokens/testing-harness.toml ← scalars (I2)
+zenos.stack.lock            ← provider bindings + pinned deps (I2 exemption)
+policy/testing-harness.toml ← profile constraints
+procedures/testing-harness/ ← hydrate + test procedures (YAML)
+zen/testing/hydrate.py      ← DECLARE / NEGOTIATE / HYDRATE implementation
+tests/test_harness_hydrate.py ← negotiation purity + hydrate properties
+```
+
+---
+
+## Profiles
+
+Bindings are chosen per **profile** (see `zenos.stack.lock`):
+
+| Profile | Use |
+|---|---|
+| `linux/wayland/chromium/dev` | Local UI/component work (VITRINE default) |
+| `ci/headless` | GitHub Actions — pytest, lint, harness validate |
+| `static/file` | Offline / file:// degradation checks (I5) |
+
+---
+
+## Current zenOS test stack (transitional)
+
+Until VITRINE runtime exists:
+
+1. **Hydrate** deps for `ci/headless` before test runs in CI.
+2. **pytest** runs unit tests in `tests/`.
+3. **test_runner.py** — legacy smoke suite; migrate checks into pytest over time.
+4. **Harness validate** — `python -m zen.testing.hydrate negotiate` must be deterministic; token keys referenced in CI must resolve.
+
+When VITRINE implements substrate + lenses, zenOS adopts it as a **provider** bound in `zenos.stack.lock`, not a forked philosophy.
+
+---
+
+## Agent onboarding path
+
+1. Read [`HOUSE_RULES.md`](HOUSE_RULES.md)
+2. Read [`TESTING.md`](TESTING.md) §0–§2 (recursion rule + D1-independent layers)
+3. Run `python -m zen.testing.hydrate status`
+4. Run `pytest tests/test_harness_hydrate.py -v`
+5. Consult [`DECISIONS.md`](DECISIONS.md) before proposing stack changes
+
+See also [`docs/AI_INSTRUCTIONS.md`](../../AI_INSTRUCTIONS.md) Step 7.
+
+---
+
+## Provisioning amendments (zenOS-applied)
+
+From [`PROVISIONING.md §9`](PROVISIONING.md), applied in this repo:
+
+- **I3′** — stack names only in `zenos.stack.lock`
+- **I7** — one mutation path via hydrate journal
+- **D4** — runner is a binding, not a permanent decision
+- **D1** — still open; spine buildable before substrate
+
+`PROVISIONING.md` remains **PROPOSED** for VITRINE core; zenOS applies the amendments locally for dependency and CI hygiene.

--- a/policy/testing-harness.toml
+++ b/policy/testing-harness.toml
@@ -1,0 +1,38 @@
+# zenOS testing harness policy — constraints for negotiation (DECLARE phase)
+# Profiles map to requirement sets; bindings resolved in zenos.stack.lock
+
+schema_version = "1"
+
+[license]
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "ISC"]
+deny_copyleft = false
+
+[profiles.ci_headless]
+id = "ci/headless"
+requirements = [
+  "execute_test_plan",
+  "resolve_python_deps",
+  "lint_python",
+]
+network_granted = true
+native_toolchain_granted = true
+
+[profiles.linux_dev]
+id = "linux/wayland/chromium/dev"
+requirements = [
+  "isolate_specimen",
+  "render_gpu_world_plane",
+  "serve_static_chrome",
+  "execute_test_plan",
+]
+network_granted = true
+native_toolchain_granted = true
+
+[profiles.static_file]
+id = "static/file"
+requirements = [
+  "serve_static_chrome",
+  "degrade_to_static",
+]
+network_granted = false
+native_toolchain_granted = false

--- a/procedures/testing-harness/hydrate.yaml
+++ b/procedures/testing-harness/hydrate.yaml
@@ -1,0 +1,88 @@
+# zenOS testing harness procedures — DECLARE / NEGOTIATE / HYDRATE
+# See docs/testing-harness/PROVISIONING.md and HOUSE_RULES.md
+
+procedure:
+  id: "zen.test.harness.status"
+  name: "Harness Status"
+  type: "diagnostic"
+  tier: "common"
+  description: "Observe harness state without mutation (P-observe)"
+  stats:
+    complexity: 15
+    efficiency: 95
+    reliability: 98
+  requirements:
+    - "tokens/testing-harness.toml"
+    - "zenos.stack.lock"
+  steps:
+    - id: observe
+      command: "python -m zen.testing.hydrate status --json"
+      mutates: false
+  outputs:
+    proposal_fingerprint: string
+    warnings: list
+    conformance: list
+
+---
+
+procedure:
+  id: "zen.test.harness.negotiate"
+  name: "Harness Negotiate"
+  type: "analytical"
+  tier: "uncommon"
+  description: "Pure negotiation — deterministic proposal, no filesystem mutation"
+  stats:
+    complexity: 35
+    efficiency: 90
+    reliability: 97
+  requirements:
+    - "policy/testing-harness.toml"
+    - "zenos.stack.lock"
+  inputs:
+    profile: string
+  steps:
+    - id: declare
+      command: "python -m zen.testing.hydrate declare --profile {profile} --json"
+      mutates: false
+    - id: negotiate
+      command: "python -m zen.testing.hydrate negotiate --profile {profile} --json"
+      mutates: false
+  halt_on:
+    - unresolved_requirement
+    - failed_binding
+    - provisional_without_ack
+
+---
+
+procedure:
+  id: "zen.test.harness.hydrate"
+  name: "Harness Hydrate"
+  type: "transformative"
+  tier: "rare"
+  description: "Journaled dependency hydration — only mutating startup path (I7)"
+  stats:
+    complexity: 55
+    efficiency: 85
+    reliability: 92
+  requirements:
+    - "approved negotiation proposal"
+    - "network if profile grants"
+  inputs:
+    profile: string
+    dry_run: boolean
+  steps:
+    - id: negotiate
+      command: "python -m zen.testing.hydrate negotiate --profile {profile} --json"
+      mutates: false
+    - id: hydrate
+      command: "python -m zen.testing.hydrate hydrate --profile {profile} --json"
+      mutates: true
+      journal: "ledger/hydrate.journal.jsonl"
+  properties:
+    - P-conv
+    - P-noop
+    - P-resume
+    - P-journal
+  evolution_path:
+    from: "zen.test.harness.negotiate"
+    next: "zen.test.harness.conformance"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ python-dotenv>=1.0
 prompt-toolkit>=3.0
 beautifulsoup4>=4.12.0
 schedule>=1.2.0
+tomli>=2.0.0; python_version < "3.11"
 
 # Testing
 pytest>=7.0.0

--- a/tests/test_harness_hydrate.py
+++ b/tests/test_harness_hydrate.py
@@ -1,0 +1,62 @@
+"""Tests for zenOS testing harness hydrate handshake (PROVISIONING §4 properties)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from zen.testing.hydrate import (
+    HydrateError,
+    declare,
+    hydrate,
+    negotiate,
+    status,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_declare_ci_profile():
+    decl = declare("ci/headless", root=ROOT)
+    assert decl["profile"] == "ci/headless"
+    assert "execute_test_plan" in decl["requirements"]
+    assert decl["probes"]["python"]["ok"]
+
+
+def test_negotiation_is_deterministic():
+    p1 = negotiate("ci/headless", root=ROOT)
+    p2 = negotiate("ci/headless", root=ROOT)
+    assert p1.fingerprint == p2.fingerprint
+    assert p1.to_dict() == p2.to_dict()
+
+
+def test_negotiation_pure_function_byte_identical():
+  """Same inputs → byte-identical proposal JSON (PROVISIONING §3)."""
+  payloads = []
+  for _ in range(3):
+      p = negotiate("ci/headless", root=ROOT)
+      payloads.append(json.dumps(p.to_dict(), sort_keys=True, separators=(",", ":")))
+  assert payloads[0] == payloads[1] == payloads[2]
+
+
+def test_failed_binding_halts():
+    with pytest.raises(HydrateError, match="FAILED"):
+        negotiate("linux/wayland/chromium/dev", root=ROOT)
+
+
+def test_status_no_mutation():
+    before = status("ci/headless", root=ROOT)
+    after = status("ci/headless", root=ROOT)
+    assert before == after
+
+
+def test_hydrate_dry_run_is_noop_install():
+    result = hydrate("ci/headless", root=ROOT, dry_run=True)
+    assert result["dry_run"] is True
+    assert all(s.get("status") == "dry_run" for s in result["steps"])
+
+
+def test_tokens_perf_specimen_count_from_file():
+    decl = declare("ci/headless", root=ROOT)
+    assert decl["tokens"]["testing"]["perf_specimen_count"] == 120

--- a/tokens/testing-harness.toml
+++ b/tokens/testing-harness.toml
@@ -1,0 +1,28 @@
+# zenOS testing harness tokens (I2 — literals live here only)
+# Referenced by policy/, CI, and zen.testing.hydrate — never inline in logic.
+
+[testing]
+# Substrate perf gate — TESTING.md §3 (value is a token, debate T3 applies)
+perf_specimen_count = 120
+perf_target_fps = 120
+
+# pytest / smoke timeouts (seconds)
+pytest_timeout = 300
+smoke_cli_timeout = 10
+
+# Provisional binding TTL — PROVISIONING P5
+provisional_binding_ttl_days = 14
+
+# Golden file policy — TESTING.md §5
+golden_auto_regen_allowed = false
+
+[viewport]
+# SPINE.md — viewport.sm.width example; axes reference these keys
+sm_width = 768
+md_width = 1024
+lg_width = 1280
+
+[ci]
+# Harness validate strictness
+require_deterministic_negotiation = true
+offline_bootstrap_required = false  # enable when VITRINE engine ships

--- a/zen/testing/__init__.py
+++ b/zen/testing/__init__.py
@@ -1,0 +1,21 @@
+"""zenOS testing harness — programmatic startup via DECLARE / NEGOTIATE / HYDRATE."""
+
+from zen.testing.hydrate import (
+    HydrateError,
+    HydrateJournal,
+    declare,
+    hydrate,
+    negotiate,
+    observe,
+    status,
+)
+
+__all__ = [
+    "HydrateError",
+    "HydrateJournal",
+    "declare",
+    "negotiate",
+    "hydrate",
+    "observe",
+    "status",
+]

--- a/zen/testing/hydrate.py
+++ b/zen/testing/hydrate.py
@@ -1,0 +1,432 @@
+"""
+DECLARE → NEGOTIATE → HYDRATE provisioning for zenOS.
+
+Implements the handshake from docs/testing-harness/PROVISIONING.md §3–§4.
+Negotiation is pure and deterministic; HYDRATE is the only mutating phase.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore
+
+
+class Phase(str, Enum):
+    DECLARE = "declare"
+    NEGOTIATE = "negotiate"
+    HYDRATE = "hydrate"
+    STATUS = "status"
+
+
+class HydrateError(Exception):
+    """Halt condition — no silent fallback."""
+
+
+@dataclass
+class Binding:
+    requirement: str
+    profile: str
+    provider: str
+    state: str
+    provenance: List[str] = field(default_factory=list)
+    note: Optional[str] = None
+
+
+@dataclass
+class Proposal:
+    profile: str
+    bindings: List[Binding]
+    delta_add: List[str]
+    delta_remove: List[str]
+    delta_change: List[str]
+    capability_requests: List[str]
+    provenance: List[str]
+    conformance_status: List[str]
+    warnings: List[str]
+    fingerprint: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "bindings": [
+                {
+                    "requirement": b.requirement,
+                    "profile": b.profile,
+                    "provider": b.provider,
+                    "state": b.state,
+                    "provenance": b.provenance,
+                    "note": b.note,
+                }
+                for b in self.bindings
+            ],
+            "deltaAdd": self.delta_add,
+            "deltaRemove": self.delta_remove,
+            "deltaChange": self.delta_change,
+            "capabilityRequests": self.capability_requests,
+            "provenance": self.provenance,
+            "conformanceStatus": self.conformance_status,
+            "warnings": self.warnings,
+            "fingerprint": self.fingerprint,
+        }
+
+
+@dataclass
+class HydrateJournal:
+    path: Path
+
+    def append(self, record: Dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+    def read_all(self) -> List[Dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        lines = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                lines.append(json.loads(line))
+        return lines
+
+
+def _root(root: Optional[Path] = None) -> Path:
+    return root or Path.cwd()
+
+
+def _load_toml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _profile_key(profile: str) -> str:
+    return profile.replace("/", "_").replace("-", "_")
+
+
+def _profile_section(policy: Dict[str, Any], profile: str) -> Dict[str, Any]:
+    profiles = policy.get("profiles", {})
+    key = _profile_key(profile)
+    if key in profiles:
+        return profiles[key]
+    for section in profiles.values():
+        if section.get("id") == profile:
+            return section
+    return {}
+
+
+def _load_tokens(root: Path) -> Dict[str, Any]:
+    return _load_toml(root / "tokens" / "testing-harness.toml")
+
+
+def _load_policy(root: Path) -> Dict[str, Any]:
+    return _load_toml(root / "policy" / "testing-harness.toml")
+
+
+def _load_lock(root: Path) -> Dict[str, Any]:
+    lock_path = root / "zenos.stack.lock"
+    if not lock_path.exists():
+        raise HydrateError(f"Missing binding lock: {lock_path}")
+    return _load_toml(lock_path)
+
+
+def _probe_environment(root: Path) -> Dict[str, Any]:
+    """Read-only probes — DECLARE phase only."""
+
+    def _run(cmd: List[str]) -> Tuple[bool, str]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=root,
+            )
+            return result.returncode == 0, (result.stdout or result.stderr).strip()
+        except (subprocess.SubprocessError, OSError) as exc:
+            return False, str(exc)
+
+    py_ok, py_ver = _run([sys.executable, "--version"])
+    pip_ok, pip_ver = _run([sys.executable, "-m", "pip", "--version"])
+    git_ok, _ = _run(["git", "--version"])
+
+    return {
+        "python": {"ok": py_ok, "version": py_ver},
+        "pip": {"ok": pip_ok, "version": pip_ver},
+        "git": {"ok": git_ok},
+        "platform": sys.platform,
+        "root": str(root.resolve()),
+    }
+
+
+def declare(profile: str, root: Optional[Path] = None) -> Dict[str, Any]:
+    """DECLARE — pure, offline, no mutation."""
+    root = _root(root)
+    policy = _load_policy(root)
+    tokens = _load_tokens(root)
+    lock = _load_lock(root)
+    probes = _probe_environment(root)
+
+    profile_section = _profile_section(policy, profile)
+    if not profile_section:
+        raise HydrateError(f"No policy profile for: {profile}")
+
+    return {
+        "phase": Phase.DECLARE.value,
+        "profile": profile,
+        "requirements": profile_section.get("requirements", []),
+        "constraints": {
+            "license": policy.get("license", {}),
+            "network_granted": profile_section.get("network_granted", False),
+            "native_toolchain_granted": profile_section.get(
+                "native_toolchain_granted", False
+            ),
+        },
+        "tokens": tokens,
+        "lock_schema": lock.get("schema_version"),
+        "probes": probes,
+        "provenance": [
+            "policy/testing-harness.toml",
+            "tokens/testing-harness.toml",
+            "zenos.stack.lock",
+        ],
+    }
+
+
+def _bindings_for_profile(lock: Dict[str, Any], profile: str) -> List[Binding]:
+    bindings: List[Binding] = []
+    for entry in lock.get("bindings", []):
+        if entry.get("profile") == profile:
+            bindings.append(
+                Binding(
+                    requirement=entry["requirement"],
+                    profile=entry["profile"],
+                    provider=entry["provider"],
+                    state=entry.get("state", "UNKNOWN"),
+                    provenance=entry.get("provenance", []),
+                    note=entry.get("note"),
+                )
+            )
+    return bindings
+
+
+def _fingerprint(payload: Dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def negotiate(profile: str, root: Optional[Path] = None) -> Proposal:
+    """NEGOTIATE — pure, offline, produces a deterministic proposal."""
+    root = _root(root)
+    declaration = declare(profile, root=root)
+    lock = _load_lock(root)
+    bindings = _bindings_for_profile(lock, profile)
+    requirements = declaration["requirements"]
+    warnings: List[str] = []
+    conformance: List[str] = []
+
+    bound_reqs = {b.requirement for b in bindings}
+    missing = [r for r in requirements if r not in bound_reqs]
+    if missing:
+        raise HydrateError(
+            f"No provider satisfies requirements under profile {profile}: {missing}"
+        )
+
+    for binding in bindings:
+        if binding.state == "FAILED":
+            raise HydrateError(
+                f"Binding FAILED: {binding.requirement} → {binding.provider}"
+            )
+        if binding.state == "PROVISIONAL":
+            warnings.append(
+                f"PROVISIONAL: {binding.requirement} → {binding.provider}"
+            )
+        conformance.append(f"{binding.requirement}:{binding.state}")
+
+    if not declaration["constraints"]["network_granted"]:
+        warnings.append("Profile denies network — hydrate will not fetch packages")
+
+    delta_add: List[str] = []
+    providers = lock.get("providers", {})
+    for binding in bindings:
+        provider = providers.get(binding.provider, {})
+        for pkg in provider.get("packages", []):
+            delta_add.append(f"{pkg.get('name')}=={pkg.get('version')}")
+
+    payload = {
+        "profile": profile,
+        "bindings": [b.requirement for b in bindings],
+        "delta_add": sorted(delta_add),
+        "requirements": sorted(requirements),
+    }
+    fp = _fingerprint(payload)
+
+    return Proposal(
+        profile=profile,
+        bindings=bindings,
+        delta_add=sorted(delta_add),
+        delta_remove=[],
+        delta_change=[],
+        capability_requests=[],
+        provenance=declaration["provenance"],
+        conformance_status=conformance,
+        warnings=warnings,
+        fingerprint=fp,
+    )
+
+
+def observe(root: Optional[Path] = None) -> Dict[str, Any]:
+    """P-observe — read actual state without mutation."""
+    root = _root(root)
+    probes = _probe_environment(root)
+    journal = HydrateJournal(root / "ledger" / "hydrate.journal.jsonl")
+    return {
+        "probes": probes,
+        "journal_entries": len(journal.read_all()),
+        "requirements_lock_exists": (root / "requirements.txt").exists(),
+    }
+
+
+def status(profile: str = "ci/headless", root: Optional[Path] = None) -> Dict[str, Any]:
+    """Combined observe + negotiate summary (no mutation)."""
+    proposal = negotiate(profile, root=root)
+    actual = observe(root=root)
+    return {
+        "profile": profile,
+        "proposal_fingerprint": proposal.fingerprint,
+        "warnings": proposal.warnings,
+        "conformance": proposal.conformance_status,
+        "actual": actual,
+    }
+
+
+def hydrate(
+    profile: str,
+    root: Optional[Path] = None,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """HYDRATE — journaled plan/apply. Only mutating phase."""
+    root = _root(root)
+    proposal = negotiate(profile, root=root)
+    journal_path = root / "ledger" / "hydrate.journal.jsonl"
+    journal = HydrateJournal(journal_path)
+
+    if not proposal.delta_add and profile == "ci/headless":
+        # Still ensure requirements.txt install for zenOS core
+        req = root / "requirements.txt"
+        if req.exists():
+            proposal.delta_add.append("requirements.txt")
+
+    plan = {
+        "profile": profile,
+        "fingerprint": proposal.fingerprint,
+        "steps": [],
+    }
+
+    if profile == "ci/headless":
+        req_file = root / "requirements.txt"
+        if req_file.exists():
+            plan["steps"].append(
+                {
+                    "id": "pip-requirements",
+                    "precondition": "requirements.txt exists",
+                    "command": [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "-r",
+                        str(req_file),
+                    ],
+                }
+            )
+
+    results: List[Dict[str, Any]] = []
+    for step in plan["steps"]:
+        record = {
+            "at": datetime.now(timezone.utc).isoformat(),
+            "phase": "hydrate",
+            "step": step["id"],
+            "status": "pending",
+            "fingerprint": proposal.fingerprint,
+        }
+        journal.append({**record, "status": "started"})
+
+        if dry_run:
+            results.append({**step, "status": "dry_run"})
+            journal.append({**record, "status": "dry_run"})
+            continue
+
+        cmd = step["command"]
+        try:
+            proc = subprocess.run(cmd, cwd=root, capture_output=True, text=True)
+            if proc.returncode != 0:
+                journal.append(
+                    {**record, "status": "failed", "stderr": proc.stderr[-500:]}
+                )
+                raise HydrateError(f"Hydrate step {step['id']} failed: {proc.stderr}")
+            journal.append({**record, "status": "completed"})
+            results.append({**step, "status": "completed"})
+        except subprocess.SubprocessError as exc:
+            journal.append({**record, "status": "failed", "error": str(exc)})
+            raise HydrateError(f"Hydrate step {step['id']} error: {exc}") from exc
+
+    return {
+        "profile": profile,
+        "fingerprint": proposal.fingerprint,
+        "warnings": proposal.warnings,
+        "steps": results,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="zenOS harness hydrate handshake")
+    parser.add_argument(
+        "phase",
+        choices=[p.value for p in Phase],
+        help="DECLARE | NEGOTIATE | HYDRATE | STATUS",
+    )
+    parser.add_argument("--profile", default="ci/headless")
+    parser.add_argument("--root", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.phase == Phase.DECLARE.value:
+            out = declare(args.profile, root=args.root)
+        elif args.phase == Phase.NEGOTIATE.value:
+            out = negotiate(args.profile, root=args.root).to_dict()
+        elif args.phase == Phase.STATUS.value:
+            out = status(args.profile, root=args.root)
+        else:
+            out = hydrate(args.profile, root=args.root, dry_run=args.dry_run)
+    except HydrateError as exc:
+        print(f"HALT: {exc}", file=sys.stderr)
+        return 1
+
+    if args.as_json:
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(out, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zenos.stack.lock
+++ b/zenos.stack.lock
@@ -1,0 +1,89 @@
+# zenOS stack binding lock (I2 exemption — package names/versions live here only)
+# Git-tracked, human-diffable. Amend via negotiate → approve → hydrate.
+# See docs/testing-harness/PROVISIONING.md
+
+schema_version = "1"
+profile_default = "ci/headless"
+
+[[bindings]]
+requirement = "execute_test_plan"
+profile = "ci/headless"
+provider = "pytest"
+state = "VERIFIED"
+provenance = ["zenos.stack.lock", "tokens/testing-harness.toml"]
+
+[[bindings]]
+requirement = "resolve_python_deps"
+profile = "ci/headless"
+provider = "pip-ci"
+state = "VERIFIED"
+provenance = ["requirements.txt", "pyproject.toml"]
+
+[[bindings]]
+requirement = "lint_python"
+profile = "ci/headless"
+provider = "black-isort-flake8"
+state = "VERIFIED"
+provenance = [".github/workflows/zenos-ci.yml"]
+
+[[bindings]]
+requirement = "execute_test_plan"
+profile = "linux/wayland/chromium/dev"
+provider = "vitrine-gauntlet"
+state = "PROVISIONAL"
+provenance = ["docs/testing-harness/TESTING.md"]
+note = "Design reference only — runtime not shipped"
+
+[[bindings]]
+requirement = "isolate_specimen"
+profile = "linux/wayland/chromium/dev"
+provider = "substrate-d1-pending"
+state = "FAILED"
+provenance = ["docs/testing-harness/DECISIONS.md#d1"]
+
+[[bindings]]
+requirement = "render_gpu_world_plane"
+profile = "linux/wayland/chromium/dev"
+provider = "wgpu-world-pending"
+state = "FAILED"
+provenance = ["docs/testing-harness/UX-STACK.md"]
+
+[[bindings]]
+requirement = "serve_static_chrome"
+profile = "linux/wayland/chromium/dev"
+provider = "astro-shell-pending"
+state = "PROVISIONAL"
+provenance = ["docs/testing-harness/UX-STACK.md"]
+
+[providers.pytest]
+ecosystem = "python"
+packages = [
+  { name = "pytest", version = "7.4.4" },
+  { name = "pytest-cov", version = "4.1.0" },
+  { name = "pytest-asyncio", version = "0.23.8" },
+]
+lockfile = "requirements.txt"
+
+[providers.pip-ci]
+ecosystem = "python"
+command = "pip install -r requirements.txt"
+replay_command = "pip install -r requirements.txt"
+note = "Use pip ci replay when lockfile semantics exist"
+
+[providers.black-isort-flake8]
+ecosystem = "python"
+packages = [
+  { name = "black", version = "24.8.0" },
+  { name = "isort", version = "5.13.2" },
+  { name = "flake8", version = "7.1.1" },
+]
+
+[providers.vitrine-gauntlet]
+ecosystem = "design"
+packages = []
+note = "VITRINE GAUNTLET — binding placeholder until runtime provider"
+
+[providers.substrate-d1-pending]
+ecosystem = "design"
+packages = []
+note = "D1 open — see DECISIONS.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates the VITRINE testing harness design doc set as zenOS's **default testing harness reference**, with house rules, token discipline, stack binding lock, and programmatic DECLARE → NEGOTIATE → HYDRATE startup.

VITRINE runtime (substrate, lenses, GAUNTLET) remains design-only; this PR lands the reference architecture and the hydration spine agents should use today.

## What's in

### Documentation (`docs/testing-harness/`)
- Full VITRINE set: VISION, SPINE, ARCHITECTURE, UX-STACK, TESTING, PROVISIONING, GLOSSARY, DECISIONS
- **HOUSE_RULES.md** — zenOS normative rules (I1–I7, tokenmaxxed literals, CI gates)
- **ZENOS_INTEGRATION.md** — repo layout, profiles, agent onboarding path

### Token + binding layer (I2)
- `tokens/testing-harness.toml` — perf gate N, timeouts, provisional TTL (no inline literals in logic)
- `zenos.stack.lock` — provider bindings + pinned package versions (second literal store)
- `policy/testing-harness.toml` — profile requirements for negotiation

### Programmatic hydration
- `zen/testing/hydrate.py` — DECLARE / NEGOTIATE / HYDRATE with journal at `ledger/hydrate.journal.jsonl`
- `procedures/testing-harness/hydrate.yaml` — dex-aligned procedure definitions
- `tests/test_harness_hydrate.py` — negotiation purity + halt properties

### Agent + CI updates
- `docs/AI_INSTRUCTIONS.md` Step 7 — harness onboarding for agents
- `README.md` — testing section + doc links
- `dex/procedures.yaml` — `zen.test.harness` procedure
- `.github/workflows/zenos-ci.yml` — `harness-validate` job; test job uses hydrate for deps

## How to verify

```bash
python -m zen.testing.hydrate negotiate --profile ci/headless --json
python -m zen.testing.hydrate hydrate --profile ci/headless --dry-run
pytest tests/test_harness_hydrate.py -v
```

## Notes

- `linux/wayland/chromium/dev` profile halts on FAILED D1 substrate binding (expected)
- PROVISIONING §9 amendments applied locally for zenOS hygiene; VITRINE core PROVISIONING doc remains marked PROPOSED
- Journal files gitignored; `ledger/.gitkeep` tracks the directory

## Type of change
- [x] New feature
- [x] Documentation update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b3356d3-42b2-4d42-a311-92ecc0014e0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b3356d3-42b2-4d42-a311-92ecc0014e0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

