### PR TITLE
feat: zenOS REST API with JSON cards, handshake, and shared services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 # Copy application code
 COPY --chown=zen:zen zen/ /app/zen/
+COPY --chown=zen:zen dex/ /app/dex/
 COPY --chown=zen:zen agents/ /app/agents/
 COPY --chown=zen:zen modules/ /app/modules/
 COPY --chown=zen:zen configs/ /app/configs/
@@ -53,8 +54,10 @@ USER zen
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app \
     ZEN_CONFIG_PATH=/config \
-    HOME=/home/zen
+    HOME=/home/zen \
+    ZEN_SERVE=1
 
-# Default command - start in chat mode
-CMD ["python", "-m", "zen.cli", "chat"]
+# Default command — REST API (override with `zen chat` for interactive)
+CMD ["python", "-m", "zen.api", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A revolutionary operating system for human-AI collaboration where biological and
 zenOS transforms your terminal into a living, breathing workspace where humans and AI agents collaborate seamlessly.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 ---
 
@@ -106,6 +106,13 @@ python -m pip install -e .
    ```bash
    zen chat
    ```
+
+5. **Or run the REST API:**
+   ```bash
+   zen serve
+   # http://127.0.0.1:8080/health  /docs  /api/v1/meta
+   ```
+   See [`docs/guides/REST_API.md`](docs/guides/REST_API.md).
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,19 +13,25 @@ services:
       - ZEN_CONFIG_PATH=/config
       - ZEN_DB_URL=postgresql://zen:${DB_PASSWORD:-zenpass}@zen-memory:5432/zenos
       - REDIS_URL=redis://zen-cache:6379
+      - ZEN_API_TOKEN=${ZEN_API_TOKEN:-}
+      - ZEN_API_HOST=0.0.0.0
+      - ZEN_API_PORT=8080
     volumes:
       - ./config:/config
       - ./workspace:/workspace
       - ~/.zenOS:/home/zen/.zenOS
       - ./zen:/app/zen:ro  # Mount source code for development
+      - ./dex:/app/dex:ro
     networks:
       - zen-network
+    ports:
+      - "8080:8080"
     stdin_open: true
     tty: true
     depends_on:
       - zen-memory
       - zen-cache
-    command: ["python", "-m", "zen.cli", "chat"]  # Default to interactive chat mode
+    command: ["python", "-m", "zen.api", "--host", "0.0.0.0", "--port", "8080"]
 
   # PostgreSQL for conversation history & vector storage
   zen-memory:

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -64,6 +64,7 @@ curl -sSL https://raw.githubusercontent.com/k-dot-greyz/zenOS/main/scripts/setup
 2. **[`dex/models.yaml`](./dex/models.yaml)** - Discover AI models
 3. **[`dex/procedures.yaml`](./dex/procedures.yaml)** - Learn procedures
 4. **[`AI_INTEGRATION_BLUEPRINT.md`](./AI_INTEGRATION_BLUEPRINT.md)** - See the future
+5. **[`REST_API.md`](./REST_API.md)** - Machine HTTP interface
 
 ---
 

--- a/docs/guides/QUICKSTART_TERMUX.md
+++ b/docs/guides/QUICKSTART_TERMUX.md
@@ -258,9 +258,17 @@ export ZEN_MAX_TOKENS=500  # Shorter responses on mobile
 
 ### Option 1: Use Your Desktop as Backend
 ```bash
-# On desktop, expose zenOS API
+# On desktop, expose zenOS API (token required off loopback)
+export ZEN_API_TOKEN="a-long-random-secret"
 cd ~/zenOS
 python -m zen.core.api --host 0.0.0.0 --port 7777
+# or: zen serve --host 0.0.0.0 --port 7777
+
+# On phone, connect to desktop
+export ZEN_REMOTE_HOST="192.168.1.100:7777"
+export ZEN_API_TOKEN="a-long-random-secret"
+curl -sS -H "Authorization: Bearer $ZEN_API_TOKEN" http://$ZEN_REMOTE_HOST/health
+```
 
 # On phone, connect to desktop
 export ZEN_REMOTE_HOST="192.168.1.100:7777"

--- a/docs/guides/REST_API.md
+++ b/docs/guides/REST_API.md
@@ -1,0 +1,113 @@
+# zenOS REST API
+
+Machine interface for agents, Dex, plugins, inbox, and chat. The CLI and HTTP
+share the same services; OpenAPI is generated at `/docs` and `/openapi.json`.
+
+## Start the server
+
+```bash
+# Loopback (token optional)
+zen serve
+# same thing:
+python -m zen.api
+python -m zen.core.api   # documented shim
+
+# LAN / Termux / Docker — token required
+export ZEN_API_TOKEN="a-long-random-secret"
+zen serve --host 0.0.0.0 --port 8080
+```
+
+Defaults: `127.0.0.1:8080`. Binding anything other than loopback without
+`ZEN_API_TOKEN` exits with an error.
+
+Env vars: `ZEN_API_HOST`, `ZEN_API_PORT`, `ZEN_API_TOKEN`, `ZEN_API_CORS`
+(comma-separated origins, never `*`). See `env.example`.
+
+## Handshake (schema dump)
+
+After connect, dump the packet schema (sysex-style). Later stream packets keep
+this schema and omit unchanged field keys.
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/v1/session \
+  ${ZEN_API_TOKEN:+-H "Authorization: Bearer $ZEN_API_TOKEN"}
+```
+
+Response is a `zen.session` card: `sid`, `packet_kinds`, `card_types`,
+`capabilities`. Pass `X-Zen-Session: <sid>` on later requests to get
+monotonically increasing `seq`.
+
+Every other JSON body is a packet:
+
+```json
+{
+  "v": 1,
+  "sid": null,
+  "seq": 0,
+  "kind": "card",
+  "type": "zen.agent",
+  "id": "critic",
+  "fields": { "name": "critic", "description": "..." }
+}
+```
+
+Errors are `kind: "error"` / `type: "zen.error"` with `code`, `message`,
+`details` — not FastAPI `{ "detail": ... }` alone.
+
+## Auth
+
+- `GET /health` is always public.
+- If `ZEN_API_TOKEN` is set, all `/api/v1/*` routes require
+  `Authorization: Bearer <token>`.
+- OpenRouter keys never appear in responses.
+
+## Endpoints
+
+| Method | Path | Card type |
+| --- | --- | --- |
+| GET | `/health` | liveness JSON `{status, version}` |
+| GET | `/api/v1/meta` | `zen.meta` |
+| POST | `/api/v1/session` | `zen.session` handshake |
+| GET | `/api/v1/cards/agents` | `zen.collection` of `zen.agent` |
+| GET | `/api/v1/cards/agents/{id}` | `zen.agent` |
+| POST | `/api/v1/agents/{id}/execute` | `zen.execute` (`?stream=true` SSE) |
+| GET | `/api/v1/cards/models` | `zen.model` (`?tier=` `?task=`) |
+| GET | `/api/v1/cards/models/{id}` | `zen.model` |
+| GET | `/api/v1/cards/procedures` | `zen.procedure` |
+| GET | `/api/v1/dex/stats` | `zen.dex.stats` |
+| POST | `/api/v1/dex/sync` | `zen.dex.stats` (needs OpenRouter) |
+| GET | `/api/v1/cards/plugins` | `zen.plugin` |
+| POST | `/api/v1/plugins/{id}/execute` | `zen.execute` |
+| GET | `/api/v1/inbox` | `zen.inbox.item` collection |
+| POST | `/api/v1/inbox` | `zen.inbox.item` |
+| POST | `/api/v1/chat` | SSE `zen.chat` deltas |
+
+Interactive docs: `http://127.0.0.1:8080/docs`.
+
+## Examples
+
+```bash
+# Health
+curl -sS http://127.0.0.1:8080/health
+
+# Dex models (legendary tier)
+curl -sS "http://127.0.0.1:8080/api/v1/cards/models?tier=legendary"
+
+# Execute an agent
+curl -sS -X POST http://127.0.0.1:8080/api/v1/agents/critic/execute \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"review this prompt","critique":false}'
+
+# Capture inbox
+curl -sS -X POST http://127.0.0.1:8080/api/v1/inbox \
+  -H "Content-Type: application/json" \
+  -d '{"type":"note","content":"idea from n8n"}'
+```
+
+SSE streams emit `kind: delta` packets (only changed fields) and finish with
+`kind: done`.
+
+## Docker
+
+`docker compose up zen-cli` serves the API on port 8080. Set `ZEN_API_TOKEN` in
+`.env` — the container binds `0.0.0.0`.

--- a/env.example
+++ b/env.example
@@ -22,3 +22,12 @@ ZEN_DEBUG=false
 
 # Cost Control (optional)
 ZEN_MAX_COST_PER_REQUEST=1.0
+
+# REST API (optional)
+# Loopback binds (127.0.0.1) work without a token.
+# Non-loopback binds (0.0.0.0, LAN IP) REQUIRE a Bearer token.
+ZEN_API_HOST=127.0.0.1
+ZEN_API_PORT=8080
+ZEN_API_TOKEN=
+# Comma-separated CORS allowlist (never use *)
+ZEN_API_CORS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,12 @@ authors = [
     {name = "Kaspars Greizis", email = "kaspars@zenos.ai"}
 ]
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -37,6 +35,10 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "schedule>=1.2.0",
     "httpx>=0.24.0",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "sse-starlette>=2.0",
+    "aiofiles>=23.0",
 ]
 
 [project.optional-dependencies]
@@ -71,7 +73,7 @@ include = ["zen*"]
 
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"
@@ -83,7 +85,7 @@ select = ["E", "F", "I", "N", "W", "B", "C90", "D"]
 ignore = ["D100", "D104"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -92,3 +94,4 @@ disallow_untyped_defs = true
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "--cov=zen --cov-report=term-missing"
+asyncio_mode = "auto"

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -1,0 +1,146 @@
+"""AgentService and /api/v1 agent card/execute endpoints."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from zen.api.app import create_app
+from zen.api.state import ApiState
+from zen.core.agent import AgentManifest
+from zen.services.agents import AgentService
+from zen.services.errors import NotFoundError
+
+
+class _FakeAgent:
+    def __init__(self, name: str, description: str = "test agent") -> None:
+        self.manifest = AgentManifest(
+            name=name,
+            description=description,
+            version="1.0.0",
+            author="tests",
+            tags=["test"],
+        )
+
+    def execute(self, prompt: str, variables: dict) -> str:
+        extra = variables.get("k", "")
+        return f"{self.manifest.name}:{prompt}:{extra}"
+
+
+class _FakeRegistry:
+    def __init__(self, agents: list[_FakeAgent]) -> None:
+        self._agents = {agent.manifest.name: agent for agent in agents}
+
+    def list_agents(self) -> list[dict]:
+        return [
+            {
+                "name": agent.manifest.name,
+                "description": agent.manifest.description,
+                "type": "custom",
+                "version": agent.manifest.version,
+                "author": agent.manifest.author,
+                "tags": agent.manifest.tags,
+            }
+            for agent in self._agents.values()
+        ]
+
+    def get_agent(self, name: str) -> _FakeAgent:
+        if name not in self._agents:
+            raise ValueError(f"Agent not found: {name}")
+        return self._agents[name]
+
+
+def _service() -> AgentService:
+    registry = _FakeRegistry([_FakeAgent("echo", "echoes prompts")])
+    return AgentService(registry=registry)
+
+
+def _client(service: AgentService | None = None) -> TestClient:
+    svc = service or _service()
+    return TestClient(create_app(api_token=None, state=ApiState(api_token=None, agent_service=svc)))
+
+
+def test_agent_service_list_and_get():
+    service = _service()
+    listed = service.list_agents()
+    assert listed[0]["name"] == "echo"
+    assert service.get_agent("echo")["description"] == "echoes prompts"
+    try:
+        service.get_agent("missing")
+        assert False, "expected NotFoundError"
+    except NotFoundError as exc:
+        assert exc.code == "not_found"
+        assert exc.status_code == 404
+
+
+def test_agent_service_execute():
+    service = _service()
+    import asyncio
+
+    result = asyncio.run(service.execute_async("echo", "hello", {"k": "x"}, no_critique=True))
+    assert result == "echo:hello:x"
+
+
+def test_list_agent_cards():
+    response = _client().get("/api/v1/cards/agents")
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["type"] == "zen.collection"
+    assert packet["fields"]["item_type"] == "zen.agent"
+    assert packet["fields"]["count"] == 1
+    assert packet["fields"]["items"][0]["id"] == "echo"
+    assert packet["fields"]["items"][0]["fields"]["name"] == "echo"
+
+
+def test_get_agent_card():
+    response = _client().get("/api/v1/cards/agents/echo")
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["kind"] == "card"
+    assert packet["type"] == "zen.agent"
+    assert packet["id"] == "echo"
+    assert packet["fields"]["version"] == "1.0.0"
+
+
+def test_execute_unknown_agent_is_zen_error_404():
+    response = _client().post("/api/v1/agents/nope/execute", json={"prompt": "hi"})
+    assert response.status_code == 404
+    packet = response.json()
+    assert packet["kind"] == "error"
+    assert packet["type"] == "zen.error"
+    assert packet["fields"]["code"] == "not_found"
+    assert packet["fields"]["details"]["id"] == "nope"
+
+
+def test_execute_agent_returns_execute_card():
+    response = _client().post(
+        "/api/v1/agents/echo/execute",
+        json={"prompt": "hi", "variables": {"k": "z"}},
+    )
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["type"] == "zen.execute"
+    assert packet["id"] == "echo"
+    assert packet["fields"]["status"] == "done"
+    assert packet["fields"]["text"] == "echo:hi:z"
+
+
+def test_execute_agent_stream_emits_delta_then_done():
+    with _client().stream(
+        "POST",
+        "/api/v1/agents/echo/execute?stream=true",
+        json={"prompt": "hi"},
+    ) as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+    kinds = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = json.loads(line[6:])
+        kinds.append(payload["kind"])
+        if payload["kind"] == "delta" and "text" in payload.get("fields", {}):
+            assert payload["fields"]["text"] == "echo:hi:"
+    assert "delta" in kinds
+    assert kinds[-1] == "done"

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -1,0 +1,38 @@
+"""Chat SSE endpoint."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from zen.api.app import create_app
+from zen.api.state import ApiState
+from zen.services.chat import ChatService
+
+
+async def _fake_completer(message: str, model: str | None):
+    for part in ("Hel", "lo"):
+        yield part
+
+
+def test_chat_streams_deltas_then_done():
+    service = ChatService(completer=_fake_completer)
+    client = TestClient(
+        create_app(api_token=None, state=ApiState(api_token=None, chat_service=service))
+    )
+    with client.stream("POST", "/api/v1/chat", json={"message": "hi"}) as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+    kinds = []
+    texts = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = json.loads(line[6:])
+        kinds.append(payload["kind"])
+        if payload["kind"] == "delta" and "text" in payload.get("fields", {}):
+            texts.append(payload["fields"]["text"])
+    assert texts == ["Hel", "lo"]
+    assert kinds[-1] == "done"
+    assert "delta" in kinds

--- a/tests/api/test_dex.py
+++ b/tests/api/test_dex.py
@@ -1,0 +1,97 @@
+"""DexService model/procedure card endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from zen.api.app import create_app
+from zen.api.state import ApiState
+from zen.dex.catalog import DexCatalog
+from zen.services.dex import DexService
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "dex"
+
+
+def _service() -> DexService:
+    catalog = DexCatalog(base_path=FIXTURES)
+    return DexService(catalog=catalog)
+
+
+def _client(service: DexService | None = None) -> TestClient:
+    svc = service or _service()
+    return TestClient(create_app(api_token=None, state=ApiState(api_token=None, dex_service=svc)))
+
+
+def test_list_models_and_filter_by_tier():
+    client = _client()
+    response = client.get("/api/v1/cards/models")
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["type"] == "zen.collection"
+    assert packet["fields"]["item_type"] == "zen.model"
+    assert packet["fields"]["count"] == 2
+    ids = {item["id"] for item in packet["fields"]["items"]}
+    assert ids == {"test/fast-model", "test/legend"}
+
+    filtered = client.get("/api/v1/cards/models", params={"tier": "legendary"})
+    assert filtered.status_code == 200
+    items = filtered.json()["fields"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == "test/legend"
+    assert items[0]["fields"]["tier"] == "legendary"
+
+
+def test_get_model_card_and_missing():
+    client = _client()
+    response = client.get("/api/v1/cards/models/test/fast-model")
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["type"] == "zen.model"
+    assert packet["id"] == "test/fast-model"
+    assert packet["fields"]["provider"] == "test"
+
+    missing = client.get("/api/v1/cards/models/nope")
+    assert missing.status_code == 404
+    assert missing.json()["fields"]["code"] == "not_found"
+
+
+def test_list_procedures_filter_and_stats():
+    client = _client()
+    response = client.get("/api/v1/cards/procedures", params={"type": "analytical"})
+    assert response.status_code == 200
+    items = response.json()["fields"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == "zen.analyze"
+
+    one = client.get("/api/v1/cards/procedures/zen.chat")
+    assert one.status_code == 200
+    assert one.json()["fields"]["name"] == "Basic Chat"
+
+    stats = client.get("/api/v1/dex/stats")
+    assert stats.status_code == 200
+    fields = stats.json()["fields"]
+    assert fields["total_models"] == 2
+    assert fields["total_procedures"] == 2
+    assert fields["model_tiers"]["legendary"] == 1
+
+
+class _FakeSyncer:
+    def __init__(self) -> None:
+        self.called = False
+        self.cache_file = Path("/tmp/zen-dex-cache-does-not-exist.json")
+
+    async def sync_dex(self) -> None:
+        self.called = True
+
+
+def test_dex_sync_uses_injected_syncer():
+    syncer = _FakeSyncer()
+    service = DexService(catalog=DexCatalog(base_path=FIXTURES), syncer=syncer)
+    client = _client(service)
+    response = client.post("/api/v1/dex/sync")
+    assert response.status_code == 200
+    assert syncer.called
+    assert response.json()["type"] == "zen.dex.stats"
+    assert response.json()["fields"]["total_models"] == 2

--- a/tests/api/test_envelope.py
+++ b/tests/api/test_envelope.py
@@ -1,0 +1,113 @@
+"""Packet envelope: handshake schema dump and sysex-style deltas."""
+
+from zen.api.envelope import (
+    CARD_TYPE_FIELDS,
+    PACKET_KINDS,
+    SCHEMA_ID,
+    SCHEMA_VERSION,
+    DeltaEncoder,
+    compact_fields,
+    handshake_schema,
+    make_card,
+    make_collection,
+    make_delta,
+    make_done,
+    make_error,
+)
+
+
+def test_handshake_schema_includes_packet_kinds_and_card_types():
+    schema = handshake_schema()
+    assert schema["schema_id"] == SCHEMA_ID
+    assert schema["v"] == SCHEMA_VERSION
+    assert set(schema["packet_kinds"]) == set(PACKET_KINDS)
+    for card_type, fields in CARD_TYPE_FIELDS.items():
+        assert card_type in schema["card_types"]
+        assert schema["card_types"][card_type]["fields"] == list(fields)
+    for cap in ("agents", "dex", "plugins", "inbox", "chat"):
+        assert cap in schema["capabilities"]
+
+
+def test_make_card_omits_none_fields_but_keeps_wire_keys():
+    packet = make_card(
+        "zen.agent",
+        "critic",
+        {"name": "critic", "description": "reviews prompts", "author": None, "version": "1.0.0"},
+        sid="sess-1",
+        seq=3,
+    )
+    wire = packet.to_wire()
+    assert wire["v"] == SCHEMA_VERSION
+    assert wire["sid"] == "sess-1"
+    assert wire["seq"] == 3
+    assert wire["kind"] == "card"
+    assert wire["type"] == "zen.agent"
+    assert wire["id"] == "critic"
+    assert wire["fields"] == {
+        "name": "critic",
+        "description": "reviews prompts",
+        "version": "1.0.0",
+    }
+    assert "author" not in wire["fields"]
+
+
+def test_delta_encoder_omits_unchanged_and_none_values():
+    encoder = DeltaEncoder()
+    first = encoder.delta({"text": "he", "status": "running", "error": None})
+    assert first == {"text": "he", "status": "running"}
+    second = encoder.delta({"text": "hello", "status": "running"})
+    assert second == {"text": "hello"}
+    third = encoder.delta({"text": "hello", "status": "running"})
+    assert third == {}
+    fourth = encoder.delta({"text": "hello", "status": "done"})
+    assert fourth == {"status": "done"}
+
+
+def test_make_delta_and_done_packets():
+    delta = make_delta("sid-a", 4, {"text": "chunk"}, card_type="zen.chat", card_id="chat-1")
+    wire = delta.to_wire()
+    assert wire["kind"] == "delta"
+    assert wire["type"] == "zen.chat"
+    assert wire["id"] == "chat-1"
+    assert wire["fields"] == {"text": "chunk"}
+
+    done = make_done("sid-a", 5, card_id="chat-1")
+    done_wire = done.to_wire()
+    assert done_wire["kind"] == "done"
+    assert done_wire["id"] == "chat-1"
+    assert done_wire["fields"] == {}
+
+
+def test_make_error_is_zen_error_card():
+    packet = make_error("not_found", "Agent not found", details={"id": "nope"}, sid="s", seq=1)
+    wire = packet.to_wire()
+    assert wire["kind"] == "error"
+    assert wire["type"] == "zen.error"
+    assert wire["fields"]["code"] == "not_found"
+    assert wire["fields"]["message"] == "Agent not found"
+    assert wire["fields"]["details"] == {"id": "nope"}
+
+
+def test_make_collection_wraps_item_cards():
+    items = [
+        make_card("zen.agent", "a", {"name": "a"}),
+        make_card("zen.agent", "b", {"name": "b"}),
+    ]
+    collection = make_collection("zen.agent", items, sid="s", seq=2)
+    wire = collection.to_wire()
+    assert wire["type"] == "zen.collection"
+    assert wire["id"] == "zen.agent"
+    assert wire["fields"]["count"] == 2
+    assert wire["fields"]["item_type"] == "zen.agent"
+    assert wire["fields"]["items"] == [
+        {"id": "a", "fields": {"name": "a"}},
+        {"id": "b", "fields": {"name": "b"}},
+    ]
+
+
+def test_compact_fields_skips_none_keeps_false_and_zero():
+    assert compact_fields({"a": None, "b": 0, "c": False, "d": ""}) == {
+        "b": 0,
+        "c": False,
+        "d": "",
+    }

--- a/tests/api/test_health_auth.py
+++ b/tests/api/test_health_auth.py
@@ -1,0 +1,110 @@
+"""Health, meta, session handshake, and Bearer auth."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware
+
+from zen.api.app import create_app
+from zen.api.auth import is_loopback_host, require_token_for_bind
+from zen.api.envelope import SCHEMA_ID, handshake_schema
+
+
+def test_health_is_public_even_with_token_configured():
+    client = TestClient(create_app(api_token="secret"))
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "version" in body
+
+
+def test_meta_open_when_no_token_configured():
+    client = TestClient(create_app(api_token=None))
+    response = client.get("/api/v1/meta")
+    assert response.status_code == 200
+    packet = response.json()
+    assert packet["kind"] == "card"
+    assert packet["type"] == "zen.meta"
+    assert packet["fields"]["schema_id"] == SCHEMA_ID
+    assert "agents" in packet["fields"]["capabilities"]
+
+
+def test_protected_route_401_without_bearer_when_token_set():
+    client = TestClient(create_app(api_token="secret"))
+    response = client.get("/api/v1/meta")
+    assert response.status_code == 401
+    packet = response.json()
+    assert packet["kind"] == "error"
+    assert packet["type"] == "zen.error"
+    assert packet["fields"]["code"] == "unauthorized"
+    assert "detail" not in packet
+
+
+def test_protected_route_ok_with_bearer_token():
+    client = TestClient(create_app(api_token="secret"))
+    response = client.get("/api/v1/meta", headers={"Authorization": "Bearer secret"})
+    assert response.status_code == 200
+    assert response.json()["type"] == "zen.meta"
+
+
+def test_invalid_bearer_token_is_unauthorized():
+    client = TestClient(create_app(api_token="secret"))
+    response = client.get("/api/v1/meta", headers={"Authorization": "Bearer nope"})
+    assert response.status_code == 401
+    assert response.json()["fields"]["code"] == "unauthorized"
+
+
+def test_session_handshake_returns_schema_dump():
+    client = TestClient(create_app(api_token=None))
+    response = client.post("/api/v1/session")
+    assert response.status_code == 201
+    packet = response.json()
+    assert packet["kind"] == "card"
+    assert packet["type"] == "zen.session"
+    sid = packet["sid"]
+    assert sid
+    assert packet["id"] == sid
+    fields = packet["fields"]
+    expected = handshake_schema()
+    assert fields["schema_id"] == expected["schema_id"]
+    assert fields["packet_kinds"] == expected["packet_kinds"]
+    assert "zen.agent" in fields["card_types"]
+    assert "name" in fields["card_types"]["zen.agent"]["fields"]
+    assert "agents" in fields["capabilities"]
+
+
+def test_unknown_route_returns_zen_error_packet():
+    client = TestClient(create_app(api_token=None))
+    response = client.get("/api/v1/does-not-exist")
+    assert response.status_code == 404
+    packet = response.json()
+    assert packet["kind"] == "error"
+    assert packet["type"] == "zen.error"
+    assert packet["fields"]["code"] == "not_found"
+
+
+def test_cors_allowlist_is_not_wildcard():
+    app = create_app()
+    cors = [m for m in app.user_middleware if m.cls is CORSMiddleware]
+    assert cors
+    origins = cors[0].kwargs.get("allow_origins") or []
+    assert "*" not in origins
+    assert "http://localhost:3000" in origins
+
+
+def test_loopback_bind_allows_missing_token():
+    require_token_for_bind("127.0.0.1", None)
+    require_token_for_bind("localhost", "optional")
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("::1")
+    assert not is_loopback_host("0.0.0.0")
+
+
+def test_non_loopback_bind_requires_token():
+    with pytest.raises(ValueError, match="ZEN_API_TOKEN"):
+        require_token_for_bind("0.0.0.0", None)
+    with pytest.raises(ValueError, match="ZEN_API_TOKEN"):
+        require_token_for_bind("192.168.1.10", "")
+    require_token_for_bind("0.0.0.0", "secret")

--- a/tests/api/test_plugins_inbox.py
+++ b/tests/api/test_plugins_inbox.py
@@ -1,0 +1,114 @@
+"""PluginService and inbox card endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from zen.api.app import create_app
+from zen.api.state import ApiState
+from zen.plugins.executor import ExecutionResult
+from zen.services.inbox import InboxService
+from zen.services.plugins import PluginService
+
+
+class _Manifest:
+    id = "com.example.text"
+    name = "Text"
+    version = "1.0.0"
+    author = "tests"
+    description = "text plugin"
+    category = "text-processing"
+    capabilities = ["text_processing"]
+
+
+class _Entry:
+    manifest = _Manifest()
+    is_active = True
+    usage_count = 3
+
+
+class _Registry:
+    def __init__(self) -> None:
+        self.plugins = {_Entry.manifest.id: _Entry()}
+
+    def get_plugin(self, plugin_id: str):
+        return self.plugins.get(plugin_id)
+
+
+class _Executor:
+    async def execute_plugin(self, plugin_id, procedure_id, input_data, context):
+        if plugin_id != "com.example.text":
+            return ExecutionResult(success=False, data=None, error=f"Plugin {plugin_id} not found")
+        if procedure_id != "run":
+            return ExecutionResult(
+                success=False, data=None, error=f"Procedure {procedure_id} not found"
+            )
+        return ExecutionResult(success=True, data={"echo": input_data}, error=None, metadata={})
+
+
+def _plugin_client() -> TestClient:
+    service = PluginService(registry=_Registry(), executor=_Executor())
+    return TestClient(
+        create_app(api_token=None, state=ApiState(api_token=None, plugin_service=service))
+    )
+
+
+def test_list_and_get_plugin_cards():
+    client = _plugin_client()
+    listed = client.get("/api/v1/cards/plugins")
+    assert listed.status_code == 200
+    packet = listed.json()
+    assert packet["fields"]["count"] == 1
+    assert packet["fields"]["items"][0]["id"] == "com.example.text"
+    assert packet["fields"]["items"][0]["fields"]["name"] == "Text"
+
+    one = client.get("/api/v1/cards/plugins/com.example.text")
+    assert one.status_code == 200
+    assert one.json()["type"] == "zen.plugin"
+    assert one.json()["fields"]["is_active"] is True
+
+    missing = client.get("/api/v1/cards/plugins/nope")
+    assert missing.status_code == 404
+    assert missing.json()["fields"]["code"] == "not_found"
+
+
+def test_execute_plugin_success_and_missing():
+    client = _plugin_client()
+    ok = client.post(
+        "/api/v1/plugins/com.example.text/execute",
+        json={"procedure_id": "run", "input": {"n": 1}},
+    )
+    assert ok.status_code == 200
+    assert ok.json()["fields"]["status"] == "done"
+    assert ok.json()["fields"]["result"] == {"echo": {"n": 1}}
+
+    missing = client.post(
+        "/api/v1/plugins/missing/execute",
+        json={"procedure_id": "run", "input": {}},
+    )
+    assert missing.status_code == 404
+
+
+def test_inbox_create_and_list(tmp_path: Path):
+    service = InboxService(base_path=tmp_path)
+    client = TestClient(
+        create_app(api_token=None, state=ApiState(api_token=None, inbox_service=service))
+    )
+    created = client.post(
+        "/api/v1/inbox",
+        json={"type": "note", "content": "hello greyZ", "metadata": {"src": "test"}},
+    )
+    assert created.status_code == 201
+    packet = created.json()
+    assert packet["type"] == "zen.inbox.item"
+    assert packet["fields"]["content"] == "hello greyZ"
+    assert packet["fields"]["status"] == "new"
+    item_id = packet["id"]
+
+    listed = client.get("/api/v1/cards/inbox")
+    assert listed.status_code == 200
+    items = listed.json()["fields"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == item_id

--- a/tests/api/test_serve.py
+++ b/tests/api/test_serve.py
@@ -1,0 +1,38 @@
+"""CLI help for the REST server entrypoints."""
+
+import pytest
+
+from zen.api.serve import build_parser, main
+from zen.core import api as core_api
+
+
+def test_serve_help_lists_host_and_port(capsys):
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--host" in out
+    assert "--port" in out
+
+
+def test_main_help_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    assert "zenOS REST API" in capsys.readouterr().out
+
+
+def test_core_api_shim_exports_main():
+    assert core_api.main is main
+
+
+def test_zen_serve_help():
+    from click.testing import CliRunner
+
+    from zen.cli import cli
+
+    result = CliRunner().invoke(cli, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "--host" in result.output
+    assert "--port" in result.output

--- a/tests/fixtures/dex/models.yaml
+++ b/tests/fixtures/dex/models.yaml
@@ -1,0 +1,35 @@
+version: "1.0.0"
+models:
+  - id: "test/fast-model"
+    name: "Fast Model"
+    provider: "test"
+    type: "chat"
+    tier: "common"
+    stats:
+      intelligence: 50
+      speed: 90
+    feats: ["speed"]
+    best_for: ["quick_question"]
+    context_window: 8000
+    cost_per_1k:
+      input: 0.001
+      output: 0.002
+  - id: "test/legend"
+    name: "Legend"
+    provider: "test"
+    type: "chat"
+    tier: "legendary"
+    stats:
+      intelligence: 99
+      speed: 40
+    feats: ["reasoning"]
+    best_for: ["complex_architecture"]
+    context_window: 200000
+    cost_per_1k:
+      input: 0.01
+      output: 0.03
+selection_guide:
+  by_task:
+    quick_question:
+      recommended: ["test/fast-model"]
+      budget: ["test/fast-model"]

--- a/tests/fixtures/dex/procedures.yaml
+++ b/tests/fixtures/dex/procedures.yaml
@@ -1,0 +1,27 @@
+version: "1.0.0"
+procedures:
+  - id: "zen.chat"
+    name: "Basic Chat"
+    type: "interactive"
+    tier: "common"
+    stats:
+      complexity: 20
+      efficiency: 85
+      reliability: 95
+    requirements:
+      - "LLM access"
+    discovered_by: "human:test"
+    usage_count: 10
+  - id: "zen.analyze"
+    name: "Code Analysis"
+    type: "analytical"
+    tier: "uncommon"
+    stats:
+      complexity: 55
+      efficiency: 82
+    requirements:
+      - "Code parser"
+    discovered_by: "human:test"
+    usage_count: 3
+achievements: []
+combos: []

--- a/zen/api/__init__.py
+++ b/zen/api/__init__.py
@@ -1,5 +1,6 @@
 """zenOS HTTP API adapters."""
 
+from zen.api.app import create_app
 from zen.api.envelope import handshake_schema, make_card, make_error
 
-__all__ = ["handshake_schema", "make_card", "make_error"]
+__all__ = ["create_app", "handshake_schema", "make_card", "make_error"]

--- a/zen/api/__init__.py
+++ b/zen/api/__init__.py
@@ -1,0 +1,5 @@
+"""zenOS HTTP API adapters."""
+
+from zen.api.envelope import handshake_schema, make_card, make_error
+
+__all__ = ["handshake_schema", "make_card", "make_error"]

--- a/zen/api/__main__.py
+++ b/zen/api/__main__.py
@@ -1,0 +1,6 @@
+"""python -m zen.api"""
+
+from zen.api.serve import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zen/api/app.py
+++ b/zen/api/app.py
@@ -17,6 +17,7 @@ from zen.api.errors import PacketError
 from zen.api.routers.health import health_router, meta_router
 from zen.api.routers.session import router as session_router
 from zen.api.state import ApiState
+from zen.services.errors import ServiceError
 
 _UNSET = object()
 
@@ -73,6 +74,13 @@ def create_app(
 
     @app.exception_handler(PacketError)
     async def packet_error_handler(request: Request, exc: PacketError) -> JSONResponse:
+        sid = request.headers.get("x-zen-session")
+        seq = request.app.state.zen.sessions.next_seq(sid)
+        packet = make_error(exc.code, exc.message, details=exc.details, sid=sid, seq=seq)
+        return JSONResponse(status_code=exc.status_code, content=packet.to_wire())
+
+    @app.exception_handler(ServiceError)
+    async def service_error_handler(request: Request, exc: ServiceError) -> JSONResponse:
         sid = request.headers.get("x-zen-session")
         seq = request.app.state.zen.sessions.next_seq(sid)
         packet = make_error(exc.code, exc.message, details=exc.details, sid=sid, seq=seq)

--- a/zen/api/app.py
+++ b/zen/api/app.py
@@ -1,0 +1,143 @@
+"""FastAPI application factory for the zenOS REST API."""
+
+from __future__ import annotations
+
+import os
+from typing import List, Optional, Sequence
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from zen import __version__
+from zen.api.envelope import make_error
+from zen.api.errors import PacketError
+from zen.api.routers.health import health_router, meta_router
+from zen.api.routers.session import router as session_router
+from zen.api.state import ApiState
+
+_UNSET = object()
+
+DEFAULT_CORS_ORIGINS = (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:8080",
+    "http://127.0.0.1:8080",
+)
+
+
+def _cors_origins(explicit: Optional[Sequence[str]] = None) -> List[str]:
+    if explicit is not None:
+        return [origin.strip() for origin in explicit if origin.strip()]
+    raw = os.getenv("ZEN_API_CORS", "")
+    if raw.strip():
+        return [origin.strip() for origin in raw.split(",") if origin.strip()]
+    return list(DEFAULT_CORS_ORIGINS)
+
+
+def _resolve_token(api_token: object) -> Optional[str]:
+    if api_token is _UNSET:
+        return os.getenv("ZEN_API_TOKEN") or None
+    return api_token or None  # type: ignore[return-value]
+
+
+def create_app(
+    *,
+    api_token: Optional[str] = _UNSET,  # type: ignore[assignment]
+    cors_origins: Optional[Sequence[str]] = None,
+    state: Optional[ApiState] = None,
+) -> FastAPI:
+    """Build the zenOS HTTP app. Pass api_token=None to disable auth explicitly."""
+    app = FastAPI(
+        title="zenOS API",
+        description="Machine interface for zenOS agents, Dex, plugins, and inbox.",
+        version=__version__,
+    )
+    resolved_token = _resolve_token(api_token)
+    if state is None:
+        app.state.zen = ApiState(api_token=resolved_token)
+    else:
+        app.state.zen = state
+        if api_token is not _UNSET:
+            app.state.zen.api_token = resolved_token
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins(cors_origins),
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-Zen-Session"],
+    )
+
+    @app.exception_handler(PacketError)
+    async def packet_error_handler(request: Request, exc: PacketError) -> JSONResponse:
+        sid = request.headers.get("x-zen-session")
+        seq = request.app.state.zen.sessions.next_seq(sid)
+        packet = make_error(exc.code, exc.message, details=exc.details, sid=sid, seq=seq)
+        return JSONResponse(status_code=exc.status_code, content=packet.to_wire())
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        sid = request.headers.get("x-zen-session")
+        seq = request.app.state.zen.sessions.next_seq(sid)
+        packet = make_error(
+            "validation_error",
+            "Request validation failed",
+            details={"errors": exc.errors()},
+            sid=sid,
+            seq=seq,
+        )
+        return JSONResponse(status_code=422, content=packet.to_wire())
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        if isinstance(exc.detail, dict) and exc.detail.get("kind") == "error":
+            return JSONResponse(status_code=exc.status_code, content=exc.detail)
+        sid = request.headers.get("x-zen-session")
+        seq = request.app.state.zen.sessions.next_seq(sid)
+        code = "not_found" if exc.status_code == 404 else "http_error"
+        message = exc.detail if isinstance(exc.detail, str) else "Request failed"
+        packet = make_error(code, str(message), sid=sid, seq=seq)
+        return JSONResponse(status_code=exc.status_code, content=packet.to_wire())
+
+    app.include_router(health_router)
+    app.include_router(meta_router)
+    app.include_router(session_router)
+    _include_optional_routers(app)
+    return app
+
+
+def _include_optional_routers(app: FastAPI) -> None:
+    """Attach resource routers if they have been implemented."""
+    try:
+        from zen.api.routers.agents import router as agents_router
+
+        app.include_router(agents_router)
+    except ImportError:
+        pass
+    try:
+        from zen.api.routers.dex import router as dex_router
+
+        app.include_router(dex_router)
+    except ImportError:
+        pass
+    try:
+        from zen.api.routers.plugins import router as plugins_router
+
+        app.include_router(plugins_router)
+    except ImportError:
+        pass
+    try:
+        from zen.api.routers.inbox import router as inbox_router
+
+        app.include_router(inbox_router)
+    except ImportError:
+        pass
+    try:
+        from zen.api.routers.chat import router as chat_router
+
+        app.include_router(chat_router)
+    except ImportError:
+        pass

--- a/zen/api/auth.py
+++ b/zen/api/auth.py
@@ -19,9 +19,7 @@ def is_loopback_host(host: str) -> bool:
 def require_token_for_bind(host: str, token: Optional[str]) -> None:
     """Refuse non-loopback binds unless an API token is configured."""
     if not is_loopback_host(host) and not token:
-        raise ValueError(
-            "ZEN_API_TOKEN is required when binding to a non-loopback address"
-        )
+        raise ValueError("ZEN_API_TOKEN is required when binding to a non-loopback address")
 
 
 async def require_api_token(

--- a/zen/api/auth.py
+++ b/zen/api/auth.py
@@ -1,0 +1,39 @@
+"""Bearer token auth and bind-address policy."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import Header, Request
+
+from zen.api.errors import PacketError
+
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return True if host is a loopback address or name."""
+    return host.strip().lower() in LOOPBACK_HOSTS
+
+
+def require_token_for_bind(host: str, token: Optional[str]) -> None:
+    """Refuse non-loopback binds unless an API token is configured."""
+    if not is_loopback_host(host) and not token:
+        raise ValueError(
+            "ZEN_API_TOKEN is required when binding to a non-loopback address"
+        )
+
+
+async def require_api_token(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+) -> None:
+    """Require Bearer token when the app was created with an API token."""
+    expected = request.app.state.zen.api_token
+    if not expected:
+        return
+    if not authorization or not authorization.startswith("Bearer "):
+        raise PacketError(401, "unauthorized", "Bearer token required")
+    provided = authorization[7:].strip()
+    if provided != expected:
+        raise PacketError(401, "unauthorized", "Invalid token")

--- a/zen/api/envelope.py
+++ b/zen/api/envelope.py
@@ -1,0 +1,222 @@
+"""JSON card packet envelope: handshake schema dump, then delta-only fields."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SCHEMA_VERSION = 1
+SCHEMA_ID = "zen.packet.v1"
+
+PACKET_KINDS = ("card", "delta", "done", "error")
+
+CARD_TYPE_FIELDS: Dict[str, tuple[str, ...]] = {
+    "zen.agent": ("name", "description", "type", "version", "author", "tags"),
+    "zen.model": (
+        "name",
+        "provider",
+        "type",
+        "tier",
+        "stats",
+        "feats",
+        "best_for",
+        "context_window",
+        "cost_per_1k",
+    ),
+    "zen.procedure": (
+        "name",
+        "type",
+        "tier",
+        "stats",
+        "requirements",
+        "discovered_by",
+        "usage_count",
+    ),
+    "zen.plugin": (
+        "name",
+        "version",
+        "author",
+        "description",
+        "category",
+        "capabilities",
+        "is_active",
+        "usage_count",
+    ),
+    "zen.inbox.item": ("type", "content", "metadata", "status", "created_at", "updated_at"),
+    "zen.error": ("code", "message", "details"),
+    "zen.meta": ("version", "schema_id", "capabilities"),
+    "zen.session": ("schema_id", "v", "packet_kinds", "card_types", "capabilities"),
+    "zen.collection": ("item_type", "count", "items"),
+    "zen.dex.stats": (
+        "total_models",
+        "total_procedures",
+        "model_tiers",
+        "procedure_types",
+        "achievements_available",
+        "combos_discovered",
+    ),
+    "zen.chat": ("text", "status", "model", "error"),
+    "zen.execute": ("text", "status", "result", "error"),
+}
+
+CAPABILITIES = ("agents", "dex", "plugins", "inbox", "chat")
+
+PacketKind = Literal["card", "delta", "done", "error"]
+
+
+def compact_fields(fields: Mapping[str, Any]) -> Dict[str, Any]:
+    """Drop None values; keep 0, False, and empty strings."""
+    return {key: value for key, value in fields.items() if value is not None}
+
+
+def handshake_schema() -> Dict[str, Any]:
+    """Full packet schema dump (sysex-style) advertised at session start."""
+    return {
+        "schema_id": SCHEMA_ID,
+        "v": SCHEMA_VERSION,
+        "packet_kinds": list(PACKET_KINDS),
+        "card_types": {
+            card_type: {"fields": list(field_names)}
+            for card_type, field_names in CARD_TYPE_FIELDS.items()
+        },
+        "capabilities": list(CAPABILITIES),
+    }
+
+
+class Packet(BaseModel):
+    """One envelope packet on the wire."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    v: int = SCHEMA_VERSION
+    sid: Optional[str] = None
+    seq: int = 0
+    kind: PacketKind
+    type: Optional[str] = None
+    id: Optional[str] = None
+    fields: Dict[str, Any] = Field(default_factory=dict)
+
+    def to_wire(self) -> Dict[str, Any]:
+        """Serialize with a stable top-level schema and compacted fields."""
+        return {
+            "v": self.v,
+            "sid": self.sid,
+            "seq": self.seq,
+            "kind": self.kind,
+            "type": self.type,
+            "id": self.id,
+            "fields": compact_fields(self.fields),
+        }
+
+
+class DeltaEncoder:
+    """Emit only fields that changed since the last snapshot."""
+
+    def __init__(self) -> None:
+        self._last: Dict[str, Any] = {}
+
+    def reset(self) -> None:
+        """Clear the last-sent snapshot."""
+        self._last = {}
+
+    def delta(self, fields: Mapping[str, Any]) -> Dict[str, Any]:
+        """Return keys whose values are new or changed; skip None and unchanged."""
+        out: Dict[str, Any] = {}
+        for key, value in fields.items():
+            if value is None:
+                continue
+            if key in self._last and self._last[key] == value:
+                continue
+            out[key] = value
+            self._last[key] = value
+        return out
+
+
+def make_card(
+    card_type: str,
+    card_id: Optional[str],
+    fields: Mapping[str, Any],
+    *,
+    sid: Optional[str] = None,
+    seq: int = 0,
+) -> Packet:
+    """Build a full card packet with None fields omitted."""
+    return Packet(
+        sid=sid,
+        seq=seq,
+        kind="card",
+        type=card_type,
+        id=card_id,
+        fields=compact_fields(fields),
+    )
+
+
+def make_delta(
+    sid: Optional[str],
+    seq: int,
+    fields: Mapping[str, Any],
+    *,
+    card_type: Optional[str] = None,
+    card_id: Optional[str] = None,
+) -> Packet:
+    """Build a delta packet; caller should already have omitted unchanged keys."""
+    return Packet(
+        sid=sid,
+        seq=seq,
+        kind="delta",
+        type=card_type,
+        id=card_id,
+        fields=compact_fields(fields),
+    )
+
+
+def make_done(
+    sid: Optional[str],
+    seq: int,
+    *,
+    card_id: Optional[str] = None,
+    card_type: Optional[str] = None,
+) -> Packet:
+    """Build a terminal done packet for a stream."""
+    return Packet(sid=sid, seq=seq, kind="done", type=card_type, id=card_id, fields={})
+
+
+def make_error(
+    code: str,
+    message: str,
+    *,
+    details: Optional[Mapping[str, Any]] = None,
+    sid: Optional[str] = None,
+    seq: int = 0,
+) -> Packet:
+    """Build a zen.error packet."""
+    return Packet(
+        sid=sid,
+        seq=seq,
+        kind="error",
+        type="zen.error",
+        id=None,
+        fields={"code": code, "message": message, "details": dict(details or {})},
+    )
+
+
+def make_collection(
+    item_type: str,
+    items: Iterable[Packet],
+    *,
+    sid: Optional[str] = None,
+    seq: int = 0,
+) -> Packet:
+    """Wrap item cards in a zen.collection packet."""
+    item_list: List[Dict[str, Any]] = []
+    for packet in items:
+        item_list.append({"id": packet.id, "fields": compact_fields(packet.fields)})
+    return Packet(
+        sid=sid,
+        seq=seq,
+        kind="card",
+        type="zen.collection",
+        id=item_type,
+        fields={"item_type": item_type, "count": len(item_list), "items": item_list},
+    )

--- a/zen/api/errors.py
+++ b/zen/api/errors.py
@@ -1,0 +1,23 @@
+"""HTTP packet errors mapped to zen.error cards."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+class PacketError(Exception):
+    """API error that serializes as a zen.error packet."""
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str,
+        *,
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = dict(details or {})

--- a/zen/api/routers/__init__.py
+++ b/zen/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers."""

--- a/zen/api/routers/agents.py
+++ b/zen/api/routers/agents.py
@@ -1,0 +1,148 @@
+"""Agent card and execute HTTP routes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Dict, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel, Field
+from sse_starlette.sse import EventSourceResponse
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import DeltaEncoder, make_card, make_collection, make_delta, make_done
+from zen.services.agents import AgentService
+
+router = APIRouter(prefix="/api/v1", tags=["agents"], dependencies=[Depends(require_api_token)])
+
+
+class ExecuteBody(BaseModel):
+    """Agent execution request."""
+
+    prompt: str
+    variables: Dict[str, Any] = Field(default_factory=dict)
+    critique: bool = False
+    upgrade_only: bool = False
+
+
+def _sid_seq(request: Request) -> tuple[Optional[str], int]:
+    sid = request.headers.get("x-zen-session")
+    return sid, request.app.state.zen.sessions.next_seq(sid)
+
+
+def get_agent_service(request: Request) -> AgentService:
+    """Return injected AgentService or construct the default."""
+    service = request.app.state.zen.agent_service
+    if service is None:
+        service = AgentService()
+        request.app.state.zen.agent_service = service
+    return service
+
+
+def _agent_fields(entry: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": entry.get("name"),
+        "description": entry.get("description"),
+        "type": entry.get("type"),
+        "version": entry.get("version"),
+        "author": entry.get("author"),
+        "tags": entry.get("tags"),
+    }
+
+
+def _execute_fields(result: Any) -> Dict[str, Any]:
+    if isinstance(result, str):
+        return {"status": "done", "text": result}
+    return {"status": "done", "result": result}
+
+
+@router.get("/cards/agents")
+async def list_agents(request: Request, service: AgentService = Depends(get_agent_service)) -> dict:
+    """List agents as a zen.collection of zen.agent cards."""
+    sid, seq = _sid_seq(request)
+    cards = [
+        make_card("zen.agent", entry["name"], _agent_fields(entry))
+        for entry in service.list_agents()
+    ]
+    return make_collection("zen.agent", cards, sid=sid, seq=seq).to_wire()
+
+
+@router.get("/cards/agents/{agent_id}")
+async def get_agent(
+    agent_id: str, request: Request, service: AgentService = Depends(get_agent_service)
+) -> dict:
+    """Return one zen.agent card."""
+    sid, seq = _sid_seq(request)
+    entry = service.get_agent(agent_id)
+    return make_card("zen.agent", agent_id, _agent_fields(entry), sid=sid, seq=seq).to_wire()
+
+
+@router.post("/agents/{agent_id}/execute")
+async def execute_agent(
+    agent_id: str,
+    body: ExecuteBody,
+    request: Request,
+    stream: bool = Query(default=False),
+    service: AgentService = Depends(get_agent_service),
+) -> Any:
+    """Execute an agent; optionally stream deltas over SSE."""
+    if stream:
+        return EventSourceResponse(
+            _stream_execute(request, service, agent_id, body),
+            media_type="text/event-stream",
+        )
+    sid, seq = _sid_seq(request)
+    result = await service.execute_async(
+        agent_id,
+        body.prompt,
+        body.variables,
+        no_critique=not body.critique,
+        upgrade_only=body.upgrade_only,
+    )
+    return make_card("zen.execute", agent_id, _execute_fields(result), sid=sid, seq=seq).to_wire()
+
+
+async def _stream_execute(
+    request: Request,
+    service: AgentService,
+    agent_id: str,
+    body: ExecuteBody,
+) -> AsyncIterator[Dict[str, str]]:
+    sid = request.headers.get("x-zen-session")
+    encoder = DeltaEncoder()
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {
+        "data": json.dumps(
+            make_delta(
+                sid,
+                seq,
+                encoder.delta({"status": "running"}),
+                card_type="zen.execute",
+                card_id=agent_id,
+            ).to_wire()
+        )
+    }
+    result = await service.execute_async(
+        agent_id,
+        body.prompt,
+        body.variables,
+        no_critique=not body.critique,
+        upgrade_only=body.upgrade_only,
+    )
+    fields = _execute_fields(result)
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {
+        "data": json.dumps(
+            make_delta(
+                sid,
+                seq,
+                encoder.delta(fields),
+                card_type="zen.execute",
+                card_id=agent_id,
+            ).to_wire()
+        )
+    }
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {
+        "data": json.dumps(make_done(sid, seq, card_id=agent_id, card_type="zen.execute").to_wire())
+    }

--- a/zen/api/routers/chat.py
+++ b/zen/api/routers/chat.py
@@ -1,0 +1,93 @@
+"""Chat SSE endpoint."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Dict, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import DeltaEncoder, make_delta, make_done
+from zen.services.chat import ChatService
+
+router = APIRouter(prefix="/api/v1", tags=["chat"], dependencies=[Depends(require_api_token)])
+
+
+class ChatBody(BaseModel):
+    """Chat request."""
+
+    message: str
+    model: Optional[str] = None
+
+
+def get_chat_service(request: Request) -> ChatService:
+    """Return injected ChatService or the default OpenRouter-backed one."""
+    service = request.app.state.zen.chat_service
+    if service is None:
+        service = ChatService()
+        request.app.state.zen.chat_service = service
+    return service
+
+
+@router.post("/chat")
+async def chat(
+    body: ChatBody,
+    request: Request,
+    service: ChatService = Depends(get_chat_service),
+) -> Any:
+    """Stream a chat completion as delta packets over SSE."""
+    return EventSourceResponse(
+        _stream_chat(request, service, body),
+        media_type="text/event-stream",
+    )
+
+
+async def _stream_chat(
+    request: Request, service: ChatService, body: ChatBody
+) -> AsyncIterator[Dict[str, str]]:
+    sid = request.headers.get("x-zen-session")
+    chat_id = sid or str(uuid4())
+    encoder = DeltaEncoder()
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {
+        "data": json.dumps(
+            make_delta(
+                sid,
+                seq,
+                encoder.delta({"status": "running", "model": body.model}),
+                card_type="zen.chat",
+                card_id=chat_id,
+            ).to_wire()
+        )
+    }
+    async for chunk in service.stream(body.message, body.model):
+        seq = request.app.state.zen.sessions.next_seq(sid)
+        yield {
+            "data": json.dumps(
+                make_delta(
+                    sid,
+                    seq,
+                    encoder.delta({"text": chunk, "status": "running"}),
+                    card_type="zen.chat",
+                    card_id=chat_id,
+                ).to_wire()
+            )
+        }
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {
+        "data": json.dumps(
+            make_delta(
+                sid,
+                seq,
+                encoder.delta({"status": "done"}),
+                card_type="zen.chat",
+                card_id=chat_id,
+            ).to_wire()
+        )
+    }
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    yield {"data": json.dumps(make_done(sid, seq, card_id=chat_id, card_type="zen.chat").to_wire())}

--- a/zen/api/routers/dex.py
+++ b/zen/api/routers/dex.py
@@ -1,0 +1,104 @@
+"""Dex model and procedure HTTP routes."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import make_card, make_collection
+from zen.services.dex import DexService
+
+router = APIRouter(prefix="/api/v1", tags=["dex"], dependencies=[Depends(require_api_token)])
+
+
+def _sid_seq(request: Request) -> tuple[Optional[str], int]:
+    sid = request.headers.get("x-zen-session")
+    return sid, request.app.state.zen.sessions.next_seq(sid)
+
+
+def get_dex_service(request: Request) -> DexService:
+    """Return injected DexService or construct the default catalog service."""
+    service = request.app.state.zen.dex_service
+    if service is None:
+        service = DexService()
+        request.app.state.zen.dex_service = service
+    return service
+
+
+@router.get("/cards/models")
+async def list_models(
+    request: Request,
+    tier: Optional[str] = Query(default=None),
+    task: Optional[str] = Query(default=None),
+    service: DexService = Depends(get_dex_service),
+) -> dict:
+    """List Dex models as zen.model cards."""
+    sid, seq = _sid_seq(request)
+    cards = [
+        make_card("zen.model", model.id, service.model_fields(model))
+        for model in service.list_models(tier=tier, task=task)
+    ]
+    return make_collection("zen.model", cards, sid=sid, seq=seq).to_wire()
+
+
+@router.get("/cards/models/{model_id:path}")
+async def get_model(
+    model_id: str, request: Request, service: DexService = Depends(get_dex_service)
+) -> dict:
+    """Return one zen.model card."""
+    sid, seq = _sid_seq(request)
+    model = service.get_model(model_id)
+    return make_card("zen.model", model.id, service.model_fields(model), sid=sid, seq=seq).to_wire()
+
+
+@router.get("/cards/procedures")
+async def list_procedures(
+    request: Request,
+    type: Optional[str] = Query(default=None, alias="type"),
+    tier: Optional[str] = Query(default=None),
+    service: DexService = Depends(get_dex_service),
+) -> dict:
+    """List Dex procedures as zen.procedure cards."""
+    sid, seq = _sid_seq(request)
+    cards = [
+        make_card("zen.procedure", procedure.id, service.procedure_fields(procedure))
+        for procedure in service.list_procedures(proc_type=type, tier=tier)
+    ]
+    return make_collection("zen.procedure", cards, sid=sid, seq=seq).to_wire()
+
+
+@router.get("/cards/procedures/{procedure_id}")
+async def get_procedure(
+    procedure_id: str, request: Request, service: DexService = Depends(get_dex_service)
+) -> dict:
+    """Return one zen.procedure card."""
+    sid, seq = _sid_seq(request)
+    procedure = service.get_procedure(procedure_id)
+    return make_card(
+        "zen.procedure",
+        procedure.id,
+        service.procedure_fields(procedure),
+        sid=sid,
+        seq=seq,
+    ).to_wire()
+
+
+@router.get("/dex/stats")
+async def dex_stats(request: Request, service: DexService = Depends(get_dex_service)) -> dict:
+    """Return Dex collection statistics."""
+    sid, seq = _sid_seq(request)
+    return make_card("zen.dex.stats", "dex", service.stats(), sid=sid, seq=seq).to_wire()
+
+
+@router.post("/dex/sync")
+async def dex_sync(
+    request: Request,
+    force: bool = Query(default=False),
+    service: DexService = Depends(get_dex_service),
+) -> dict:
+    """Sync Dex from OpenRouter and return updated stats."""
+    sid, seq = _sid_seq(request)
+    stats = await service.sync(force=force)
+    return make_card("zen.dex.stats", "dex", stats, sid=sid, seq=seq).to_wire()

--- a/zen/api/routers/health.py
+++ b/zen/api/routers/health.py
@@ -1,0 +1,37 @@
+"""Health and version routers."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from zen import __version__
+from zen.api.auth import require_api_token
+from zen.api.envelope import CAPABILITIES, SCHEMA_ID, make_card
+
+health_router = APIRouter(tags=["health"])
+meta_router = APIRouter(prefix="/api/v1", tags=["meta"], dependencies=[Depends(require_api_token)])
+
+
+@health_router.get("/health")
+async def health() -> dict:
+    """Liveness probe; unauthenticated by design."""
+    return {"status": "ok", "version": __version__}
+
+
+@meta_router.get("/meta")
+async def meta(request: Request) -> dict:
+    """Advertise API version, schema id, and capabilities."""
+    sid = request.headers.get("x-zen-session")
+    seq = request.app.state.zen.sessions.next_seq(sid)
+    packet = make_card(
+        "zen.meta",
+        "zenos",
+        {
+            "version": __version__,
+            "schema_id": SCHEMA_ID,
+            "capabilities": list(CAPABILITIES),
+        },
+        sid=sid,
+        seq=seq,
+    )
+    return packet.to_wire()

--- a/zen/api/routers/inbox.py
+++ b/zen/api/routers/inbox.py
@@ -37,6 +37,7 @@ def get_inbox_service(request: Request) -> InboxService:
 
 
 @router.get("/cards/inbox")
+@router.get("/inbox")
 async def list_inbox(
     request: Request,
     status_filter: Optional[str] = Query(default=None, alias="status"),

--- a/zen/api/routers/inbox.py
+++ b/zen/api/routers/inbox.py
@@ -1,0 +1,65 @@
+"""Inbox HTTP routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Query, Request, status
+from pydantic import BaseModel, Field
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import make_card, make_collection
+from zen.services.inbox import InboxService
+
+router = APIRouter(prefix="/api/v1", tags=["inbox"], dependencies=[Depends(require_api_token)])
+
+
+class InboxCreateBody(BaseModel):
+    """New inbox item."""
+
+    type: str
+    content: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+def _sid_seq(request: Request) -> tuple[Optional[str], int]:
+    sid = request.headers.get("x-zen-session")
+    return sid, request.app.state.zen.sessions.next_seq(sid)
+
+
+def get_inbox_service(request: Request) -> InboxService:
+    """Return injected InboxService or construct the default."""
+    service = request.app.state.zen.inbox_service
+    if service is None:
+        service = InboxService()
+        request.app.state.zen.inbox_service = service
+    return service
+
+
+@router.get("/cards/inbox")
+async def list_inbox(
+    request: Request,
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    service: InboxService = Depends(get_inbox_service),
+) -> dict:
+    """List inbox items as zen.inbox.item cards."""
+    sid, seq = _sid_seq(request)
+    cards = [
+        make_card("zen.inbox.item", item["id"], service.item_fields(item))
+        for item in service.list_items(status_filter)
+    ]
+    return make_collection("zen.inbox.item", cards, sid=sid, seq=seq).to_wire()
+
+
+@router.post("/inbox", status_code=status.HTTP_201_CREATED)
+async def create_inbox_item(
+    body: InboxCreateBody,
+    request: Request,
+    service: InboxService = Depends(get_inbox_service),
+) -> dict:
+    """Capture a new inbox item."""
+    sid, seq = _sid_seq(request)
+    item = service.add_item(body.type, body.content, body.metadata)
+    return make_card(
+        "zen.inbox.item", item["id"], service.item_fields(item), sid=sid, seq=seq
+    ).to_wire()

--- a/zen/api/routers/plugins.py
+++ b/zen/api/routers/plugins.py
@@ -1,0 +1,86 @@
+"""Plugin card and execute HTTP routes."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import make_card, make_collection
+from zen.plugins.executor import ExecutionContext
+from zen.services.plugins import PluginService
+
+router = APIRouter(prefix="/api/v1", tags=["plugins"], dependencies=[Depends(require_api_token)])
+
+
+class PluginExecuteBody(BaseModel):
+    """Plugin procedure execution request."""
+
+    procedure_id: str
+    input: Any = Field(default_factory=dict)
+    user_id: str = "api"
+
+
+def _sid_seq(request: Request) -> tuple[Optional[str], int]:
+    sid = request.headers.get("x-zen-session")
+    return sid, request.app.state.zen.sessions.next_seq(sid)
+
+
+def get_plugin_service(request: Request) -> PluginService:
+    """Return injected PluginService or construct the default."""
+    service = request.app.state.zen.plugin_service
+    if service is None:
+        service = PluginService()
+        request.app.state.zen.plugin_service = service
+    return service
+
+
+@router.get("/cards/plugins")
+async def list_plugins(
+    request: Request, service: PluginService = Depends(get_plugin_service)
+) -> dict:
+    """List installed plugins as zen.plugin cards."""
+    sid, seq = _sid_seq(request)
+    cards = [
+        make_card("zen.plugin", entry.manifest.id, service.plugin_fields(entry))
+        for entry in service.list_plugins()
+    ]
+    return make_collection("zen.plugin", cards, sid=sid, seq=seq).to_wire()
+
+
+@router.get("/cards/plugins/{plugin_id}")
+async def get_plugin(
+    plugin_id: str, request: Request, service: PluginService = Depends(get_plugin_service)
+) -> dict:
+    """Return one zen.plugin card."""
+    sid, seq = _sid_seq(request)
+    entry = service.get_plugin(plugin_id)
+    return make_card(
+        "zen.plugin", entry.manifest.id, service.plugin_fields(entry), sid=sid, seq=seq
+    ).to_wire()
+
+
+@router.post("/plugins/{plugin_id}/execute")
+async def execute_plugin(
+    plugin_id: str,
+    body: PluginExecuteBody,
+    request: Request,
+    service: PluginService = Depends(get_plugin_service),
+) -> dict:
+    """Execute a plugin procedure and return a zen.execute card."""
+    sid, seq = _sid_seq(request)
+    context = ExecutionContext(
+        user_id=body.user_id,
+        session_id=sid or "local",
+        device_info={"source": "api"},
+    )
+    result = await service.execute(plugin_id, body.procedure_id, body.input, context)
+    return make_card(
+        "zen.execute",
+        plugin_id,
+        {"status": "done", "result": result.data},
+        sid=sid,
+        seq=seq,
+    ).to_wire()

--- a/zen/api/routers/session.py
+++ b/zen/api/routers/session.py
@@ -1,0 +1,21 @@
+"""Session handshake router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request, status
+
+from zen.api.auth import require_api_token
+from zen.api.envelope import handshake_schema, make_card
+
+router = APIRouter(
+    prefix="/api/v1", tags=["session"], dependencies=[Depends(require_api_token)]
+)
+
+
+@router.post("/session", status_code=status.HTTP_201_CREATED)
+async def create_session(request: Request) -> dict:
+    """Handshake: allocate a session id and dump the packet schema."""
+    sid = request.app.state.zen.sessions.create()
+    schema = handshake_schema()
+    packet = make_card("zen.session", sid, schema, sid=sid, seq=0)
+    return packet.to_wire()

--- a/zen/api/routers/session.py
+++ b/zen/api/routers/session.py
@@ -7,9 +7,7 @@ from fastapi import APIRouter, Depends, Request, status
 from zen.api.auth import require_api_token
 from zen.api.envelope import handshake_schema, make_card
 
-router = APIRouter(
-    prefix="/api/v1", tags=["session"], dependencies=[Depends(require_api_token)]
-)
+router = APIRouter(prefix="/api/v1", tags=["session"], dependencies=[Depends(require_api_token)])
 
 
 @router.post("/session", status_code=status.HTTP_201_CREATED)

--- a/zen/api/serve.py
+++ b/zen/api/serve.py
@@ -1,0 +1,68 @@
+"""Run the zenOS REST API (uvicorn)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Optional, Sequence
+
+from zen.api.auth import require_token_for_bind
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8080
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """CLI parser for `zen serve` / `python -m zen.api`."""
+    parser = argparse.ArgumentParser(
+        prog="zen serve",
+        description="Run the zenOS REST API",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("ZEN_API_HOST", DEFAULT_HOST),
+        help=f"Bind host (default {DEFAULT_HOST}; non-loopback requires ZEN_API_TOKEN)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("ZEN_API_PORT", str(DEFAULT_PORT))),
+        help=f"Bind port (default {DEFAULT_PORT})",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Reload on code changes (development)",
+    )
+    return parser
+
+
+def run_server(host: str, port: int, reload: bool = False) -> None:
+    """Validate bind policy and start uvicorn."""
+    token = os.getenv("ZEN_API_TOKEN")
+    require_token_for_bind(host, token)
+    import uvicorn
+
+    uvicorn.run(
+        "zen.api.app:create_app",
+        factory=True,
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Parse args and serve. Returns a process exit code."""
+    args = build_parser().parse_args(argv)
+    try:
+        run_server(args.host, args.port, args.reload)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zen/api/session.py
+++ b/zen/api/session.py
@@ -1,0 +1,30 @@
+"""In-memory API session store for handshake sequence numbers."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from uuid import uuid4
+
+
+class SessionStore:
+    """Track handshake sessions and monotonically increasing packet seq."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, int] = {}
+
+    def create(self) -> str:
+        """Create a session and return its id."""
+        sid = str(uuid4())
+        self._sessions[sid] = 0
+        return sid
+
+    def exists(self, sid: str) -> bool:
+        """Return True if the session was created via handshake."""
+        return sid in self._sessions
+
+    def next_seq(self, sid: Optional[str]) -> int:
+        """Increment and return seq for a known session; 0 if anonymous."""
+        if not sid or sid not in self._sessions:
+            return 0
+        self._sessions[sid] += 1
+        return self._sessions[sid]

--- a/zen/api/state.py
+++ b/zen/api/state.py
@@ -1,0 +1,21 @@
+"""Shared FastAPI application state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from zen.api.session import SessionStore
+
+
+@dataclass
+class ApiState:
+    """Injectable services and auth config for the HTTP app."""
+
+    api_token: Optional[str] = None
+    sessions: SessionStore = field(default_factory=SessionStore)
+    agent_service: Any = None
+    dex_service: Any = None
+    plugin_service: Any = None
+    inbox_service: Any = None
+    chat_service: Any = None

--- a/zen/cli.py
+++ b/zen/cli.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -355,6 +356,23 @@ def setup(unattended, validate_only, phase):
         sys.exit(1)
 
 
+@cli.command("serve")
+@click.option("--host", default=None, help="Bind host (default 127.0.0.1)")
+@click.option("--port", default=None, type=int, help="Bind port (default 8080)")
+@click.option("--reload", is_flag=True, help="Reload on code changes")
+def serve(host: Optional[str], port: Optional[int], reload: bool) -> None:
+    """Run the zenOS REST API."""
+    from zen.api.serve import run_server
+
+    bind_host = host or os.getenv("ZEN_API_HOST", "127.0.0.1")
+    bind_port = port if port is not None else int(os.getenv("ZEN_API_PORT", "8080"))
+    try:
+        run_server(bind_host, bind_port, reload)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        sys.exit(2)
+
+
 # Add plugin commands to CLI
 cli.add_command(plugins)
 cli.add_command(receive)
@@ -373,5 +391,10 @@ cli.add_command(sync)
 cli.add_command(arena)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Console script entry point for `zen` / `zenos`."""
     cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/zen/cli.py
+++ b/zen/cli.py
@@ -23,9 +23,7 @@ from rich.table import Table
 from zen import __version__
 from zen.cli_plugins import plugins
 from zen.core.agent import AgentRegistry
-from zen.core.launcher import Launcher
 from zen.inbox import receive
-from zen.utils.config import Config
 
 console = Console()
 
@@ -169,8 +167,9 @@ def run(
 
 def show_agents() -> None:
     """Display all available agents in a beautiful table."""
-    registry = AgentRegistry()
-    agents = registry.list_agents()
+    from zen.services.agents import AgentService
+
+    agents = AgentService().list_agents()
 
     if not agents:
         console.print("[yellow]No agents found.[/yellow]")
@@ -246,6 +245,9 @@ def run_agent(
     debug: bool,
 ) -> None:
     """Run an agent with the given prompt."""
+    from zen.services.agents import AgentService
+    from zen.services.errors import NotFoundError, ServiceError
+
     console.print(
         Panel.fit(
             f"[bold cyan]🧘 Running Agent:[/bold cyan] {agent}",
@@ -253,7 +255,7 @@ def run_agent(
         )
     )
 
-    launcher = Launcher(debug=debug)
+    service = AgentService(debug=debug)
 
     try:
         with Progress(
@@ -261,34 +263,33 @@ def run_agent(
             TextColumn("[progress.description]{task.description}"),
             console=console,
         ) as progress:
-            # Load agent
             task = progress.add_task("Loading agent...", total=None)
-            launcher.load_agent(agent)
+            service.get_agent(agent)
             progress.update(task, completed=True)
 
-            # Auto-critique unless disabled
-            if not no_critique:
-                task = progress.add_task("Enhancing prompt with auto-critique...", total=None)
-                prompt = launcher.critique_prompt(prompt)
-                progress.update(task, completed=True)
-
-                if upgrade_only:
-                    console.print("\n[green]✓[/green] Prompt upgraded successfully!")
-                    console.print(Panel(prompt, title="Enhanced Prompt", border_style="green"))
-                    return
-
-            # Execute agent
             task = progress.add_task("Executing agent...", total=None)
-            result = launcher.execute(prompt, variables)
+            result = service.execute(
+                agent,
+                prompt,
+                variables,
+                no_critique=no_critique,
+                upgrade_only=upgrade_only,
+            )
             progress.update(task, completed=True)
 
-        # Display result
+        if upgrade_only:
+            upgraded = (
+                result.get("upgraded_prompt", prompt) if isinstance(result, dict) else result
+            )
+            console.print("\n[green]✓[/green] Prompt upgraded successfully!")
+            console.print(Panel(str(upgraded), title="Enhanced Prompt", border_style="green"))
+            return
+
         console.print("\n[green]✓[/green] Agent completed successfully!")
 
         if isinstance(result, str):
             console.print(Panel(result, title="Result", border_style="green"))
         else:
-            # Pretty print JSON/dict results
             syntax = Syntax(
                 json.dumps(result, indent=2),
                 "json",
@@ -297,6 +298,9 @@ def run_agent(
             )
             console.print(Panel(syntax, title="Result", border_style="green"))
 
+    except (NotFoundError, ServiceError) as e:
+        console.print(f"\n[red]✗[/red] Agent failed: {e.message}")
+        sys.exit(1)
     except Exception as e:
         console.print(f"\n[red]✗[/red] Agent failed: {e}")
         if debug:

--- a/zen/cli.py
+++ b/zen/cli.py
@@ -279,9 +279,7 @@ def run_agent(
             progress.update(task, completed=True)
 
         if upgrade_only:
-            upgraded = (
-                result.get("upgraded_prompt", prompt) if isinstance(result, dict) else result
-            )
+            upgraded = result.get("upgraded_prompt", prompt) if isinstance(result, dict) else result
             console.print("\n[green]✓[/green] Prompt upgraded successfully!")
             console.print(Panel(str(upgraded), title="Enhanced Prompt", border_style="green"))
             return

--- a/zen/core/agent.py
+++ b/zen/core/agent.py
@@ -3,6 +3,7 @@ Agent base class and registry for zenOS.
 """
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,6 +13,8 @@ import yaml
 
 from zen.utils.config import Config
 from zen.utils.template import TemplateEngine
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -156,7 +159,7 @@ class AgentRegistry:
                     manifest = AgentManifest.from_yaml(yaml_file)
                     self._agents[manifest.name] = YAMLAgent(manifest)
                 except Exception as e:
-                    print(f"Failed to load agent {yaml_file}: {e}")
+                    logger.warning("Failed to load agent %s: %s", yaml_file, e)
 
         # Load built-in agents
         self._load_builtin_agents()
@@ -211,8 +214,8 @@ class AgentRegistry:
             self._agents["system_troubleshooter"] = SystemTroubleshooterAgent()
             self._agents["prompt_security"] = PromptSecurityAgent()
 
-        except ImportError as e:
-            print(f"Warning: Could not load PromptOS agents: {e}")
+        except Exception as e:
+            logger.warning("Could not load PromptOS agents: %s", e)
 
     def get_agent(self, name: str) -> Agent:
         """Get an agent by name."""

--- a/zen/core/api.py
+++ b/zen/core/api.py
@@ -1,0 +1,10 @@
+"""Compatibility shim for `python -m zen.core.api`.
+
+Historical docs and Termux guides call this module. The HTTP app lives in
+`zen.api`; this module forwards to the same server entrypoint.
+"""
+
+from zen.api.serve import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zen/core/launcher.py
+++ b/zen/core/launcher.py
@@ -2,17 +2,17 @@
 Launcher for zenOS - orchestrates agent execution with AI providers.
 """
 
+from __future__ import annotations
+
 import asyncio
+import logging
 from typing import Any, Dict, Optional
 
-from rich.console import Console
-
-from zen.agents.promptos.prompt_critic import PromptCriticAgent
 from zen.core.agent import AgentRegistry
-from zen.providers.openrouter import ModelTier, OpenRouterProvider
+from zen.providers.openrouter import OpenRouterProvider
 from zen.utils.config import Config
 
-console = Console()
+logger = logging.getLogger(__name__)
 
 
 class Launcher:
@@ -20,26 +20,33 @@ class Launcher:
     Main launcher for executing agents with AI capabilities.
     """
 
-    def __init__(self, debug: bool = False):
+    def __init__(
+        self,
+        debug: bool = False,
+        registry: Optional[AgentRegistry] = None,
+        config: Optional[Config] = None,
+    ):
         """Initialize the launcher."""
         self.debug = debug
-        self.config = Config()
-        self.registry = AgentRegistry()
+        self.config = config or Config()
+        self.registry = registry or AgentRegistry()
         self.current_agent = None
         self.provider = None
         self.prompt_critic = None
 
-        # Initialize provider if configured
         if self.config.config.openrouter_api_key:
-            self.provider = OpenRouterProvider(self.config.config.openrouter_api_key)
-            # Initialize PromptOS critique system
-            self.prompt_critic = PromptCriticAgent()
+            try:
+                self.provider = OpenRouterProvider(self.config.config.openrouter_api_key)
+                from zen.agents.promptos.prompt_critic import PromptCriticAgent
+
+                self.prompt_critic = PromptCriticAgent()
+            except Exception as exc:
+                logger.warning("AI provider init failed: %s", exc)
 
     def load_agent(self, name: str):
         """Load an agent by name."""
         self.current_agent = self.registry.get_agent(name)
-        if self.debug:
-            console.print(f"[dim]Loaded agent: {name}[/dim]")
+        logger.debug("Loaded agent: %s", name)
 
     async def critique_prompt_async(self, prompt: str) -> str:
         """
@@ -55,17 +62,15 @@ class Launcher:
             return prompt
 
         if not self.prompt_critic:
-            console.print("[yellow]Warning: PromptOS critique system not available[/yellow]")
+            logger.warning("PromptOS critique system not available")
             return prompt
 
         try:
-            # Use PromptOS critique system
             improved_prompt = self.prompt_critic.get_improved_prompt(prompt)
-            if self.debug:
-                console.print("[dim]Prompt enhanced using PromptOS critique system[/dim]")
+            logger.debug("Prompt enhanced using PromptOS critique system")
             return improved_prompt
-        except Exception as e:
-            console.print(f"[yellow]Warning: Critique failed: {e}[/yellow]")
+        except Exception as exc:
+            logger.warning("Critique failed: %s", exc)
             return prompt
 
     def critique_prompt(self, prompt: str) -> str:
@@ -86,13 +91,11 @@ class Launcher:
         if not self.current_agent:
             raise ValueError("No agent loaded")
 
-        # Check if agent has async execution method
         if hasattr(self.current_agent, "execute_async"):
             return await self.current_agent.execute_async(prompt, variables)
-        elif hasattr(self.current_agent, "execute"):
+        if hasattr(self.current_agent, "execute"):
             return self.current_agent.execute(prompt, variables)
-        else:
-            raise ValueError(f"Agent {self.current_agent.manifest.name} has no execute method")
+        raise ValueError(f"Agent {self.current_agent.manifest.name} has no execute method")
 
     def execute(self, prompt: str, variables: Dict[str, Any]) -> Any:
         """Synchronous wrapper for execute_async."""

--- a/zen/inbox.py
+++ b/zen/inbox.py
@@ -19,6 +19,13 @@ class InboxManager:
         self.incoming_path = self.inbox_path / "incoming"
         self.processing_path = self.inbox_path / "processing"
         self.processed_path = self.inbox_path / "processed"
+        for path in (
+            self.inbox_path,
+            self.incoming_path,
+            self.processing_path,
+            self.processed_path,
+        ):
+            path.mkdir(parents=True, exist_ok=True)
 
     def add_item(self, item_type: str, content: str, metadata: Dict[str, Any] = None) -> str:
         """Add a new item to the inbox"""
@@ -95,7 +102,6 @@ class InboxManager:
 
 
 @click.group()
-@click.alias("inbox")
 def receive():
     """zenOS Receive System - Process incoming items"""
     pass

--- a/zen/services/__init__.py
+++ b/zen/services/__init__.py
@@ -1,0 +1,5 @@
+"""zenOS application services shared by CLI and HTTP."""
+
+from zen.services.errors import NotFoundError, ServiceError, UnavailableError
+
+__all__ = ["NotFoundError", "ServiceError", "UnavailableError"]

--- a/zen/services/agents.py
+++ b/zen/services/agents.py
@@ -1,0 +1,98 @@
+"""Agent list/get/execute use cases shared by CLI and HTTP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from zen.core.agent import AgentRegistry
+from zen.core.launcher import Launcher
+from zen.services.errors import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class AgentService:
+    """Orchestrate agent catalog and execution without terminal I/O."""
+
+    def __init__(
+        self,
+        registry: Optional[AgentRegistry] = None,
+        launcher: Optional[Launcher] = None,
+        debug: bool = False,
+    ) -> None:
+        self._registry = registry
+        self._launcher = launcher
+        self.debug = debug
+
+    def _get_registry(self) -> AgentRegistry:
+        if self._registry is None:
+            self._registry = AgentRegistry()
+        return self._registry
+
+    def list_agents(self) -> list[Dict[str, Any]]:
+        """Return agent catalog entries."""
+        return self._get_registry().list_agents()
+
+    def get_agent(self, name: str) -> Dict[str, Any]:
+        """Return one catalog entry or raise NotFoundError."""
+        for entry in self.list_agents():
+            if entry["name"] == name:
+                return entry
+        raise NotFoundError(f"Agent not found: {name}", details={"id": name})
+
+    def _launcher_for(self, agent: Any) -> Launcher:
+        if self._launcher is not None:
+            self._launcher.current_agent = agent
+            return self._launcher
+        launcher = Launcher(debug=self.debug, registry=self._get_registry())
+        launcher.current_agent = agent
+        return launcher
+
+    async def execute_async(
+        self,
+        name: str,
+        prompt: str,
+        variables: Optional[Dict[str, Any]] = None,
+        *,
+        no_critique: bool = True,
+        upgrade_only: bool = False,
+    ) -> Any:
+        """Execute a named agent and return its raw result."""
+        registry = self._get_registry()
+        try:
+            agent = registry.get_agent(name)
+        except ValueError as exc:
+            raise NotFoundError(f"Agent not found: {name}", details={"id": name}) from exc
+
+        launcher = self._launcher_for(agent)
+        vars_in = variables or {}
+        if not no_critique:
+            prompt = await launcher.critique_prompt_async(prompt)
+            if upgrade_only:
+                return {"upgraded_prompt": prompt}
+        elif upgrade_only:
+            return {"upgraded_prompt": prompt}
+        return await launcher.execute_async(prompt, vars_in)
+
+    def execute(
+        self,
+        name: str,
+        prompt: str,
+        variables: Optional[Dict[str, Any]] = None,
+        *,
+        no_critique: bool = True,
+        upgrade_only: bool = False,
+    ) -> Any:
+        """Synchronous wrapper for execute_async."""
+        import asyncio
+
+        return asyncio.run(
+            self.execute_async(
+                name,
+                prompt,
+                variables,
+                no_critique=no_critique,
+                upgrade_only=upgrade_only,
+            )
+        )

--- a/zen/services/chat.py
+++ b/zen/services/chat.py
@@ -24,7 +24,9 @@ class ChatService:
         try:
             from zen.providers.openrouter import OpenRouterProvider
         except Exception as exc:
-            raise UnavailableError("Chat provider is not available", details={"error": str(exc)}) from exc
+            raise UnavailableError(
+                "Chat provider is not available", details={"error": str(exc)}
+            ) from exc
         try:
             async with OpenRouterProvider() as provider:
                 async for chunk in provider.complete(message, model=model, stream=True):

--- a/zen/services/chat.py
+++ b/zen/services/chat.py
@@ -1,0 +1,33 @@
+"""Chat completions streamed as delta packets."""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Callable, Optional
+
+from zen.services.errors import UnavailableError
+
+Completer = Callable[[str, Optional[str]], AsyncIterator[str]]
+
+
+class ChatService:
+    """Stream chat tokens from OpenRouter or an injected completer."""
+
+    def __init__(self, completer: Optional[Completer] = None) -> None:
+        self._completer = completer
+
+    async def stream(self, message: str, model: Optional[str] = None) -> AsyncIterator[str]:
+        """Yield text chunks for a chat message."""
+        if self._completer is not None:
+            async for chunk in self._completer(message, model):
+                yield chunk
+            return
+        try:
+            from zen.providers.openrouter import OpenRouterProvider
+        except Exception as exc:
+            raise UnavailableError("Chat provider is not available", details={"error": str(exc)}) from exc
+        try:
+            async with OpenRouterProvider() as provider:
+                async for chunk in provider.complete(message, model=model, stream=True):
+                    yield chunk
+        except ValueError as exc:
+            raise UnavailableError(str(exc)) from exc

--- a/zen/services/dex.py
+++ b/zen/services/dex.py
@@ -54,7 +54,9 @@ class DexService:
             "usage_count": procedure.usage_count,
         }
 
-    def list_models(self, *, tier: Optional[str] = None, task: Optional[str] = None) -> List[ModelEntry]:
+    def list_models(
+        self, *, tier: Optional[str] = None, task: Optional[str] = None
+    ) -> List[ModelEntry]:
         """List models, optionally filtered by tier or task."""
         if task:
             models = self.catalog.find_model_for_task(task)

--- a/zen/services/dex.py
+++ b/zen/services/dex.py
@@ -1,0 +1,116 @@
+"""Dex catalog use cases shared by CLI and HTTP."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from zen.dex.catalog import DexCatalog, ModelEntry, ProcedureEntry, Tier
+from zen.services.errors import NotFoundError, ServiceError
+
+
+class DexService:
+    """Read models/procedures from the Dex catalog."""
+
+    def __init__(self, catalog: Optional[DexCatalog] = None, syncer: Any = None) -> None:
+        self.catalog = catalog or DexCatalog()
+        self._syncer = syncer
+
+    def _tier(self, value: Optional[str]) -> Optional[Tier]:
+        if value is None:
+            return None
+        try:
+            return Tier(value)
+        except ValueError as exc:
+            raise ServiceError(
+                f"Unknown tier: {value}",
+                code="validation_error",
+                status_code=422,
+                details={"tier": value},
+            ) from exc
+
+    def model_fields(self, model: ModelEntry) -> Dict[str, Any]:
+        """Serialize a model entry to card fields."""
+        return {
+            "name": model.name,
+            "provider": model.provider,
+            "type": model.type,
+            "tier": model.tier.value,
+            "stats": model.stats,
+            "feats": model.feats,
+            "best_for": model.best_for,
+            "context_window": model.context_window,
+            "cost_per_1k": model.cost_per_1k,
+        }
+
+    def procedure_fields(self, procedure: ProcedureEntry) -> Dict[str, Any]:
+        """Serialize a procedure entry to card fields."""
+        return {
+            "name": procedure.name,
+            "type": procedure.type,
+            "tier": procedure.tier.value,
+            "stats": procedure.stats,
+            "requirements": procedure.requirements,
+            "discovered_by": procedure.discovered_by,
+            "usage_count": procedure.usage_count,
+        }
+
+    def list_models(self, *, tier: Optional[str] = None, task: Optional[str] = None) -> List[ModelEntry]:
+        """List models, optionally filtered by tier or task."""
+        if task:
+            models = self.catalog.find_model_for_task(task)
+        elif tier:
+            models = self.catalog.get_models_by_tier(self._tier(tier))
+        else:
+            models = list(self.catalog.models.values())
+        if tier and task:
+            wanted = self._tier(tier)
+            models = [model for model in models if model.tier == wanted]
+        return models
+
+    def get_model(self, model_id: str) -> ModelEntry:
+        """Return one model or raise NotFoundError."""
+        model = self.catalog.models.get(model_id)
+        if model is None:
+            raise NotFoundError(f"Model not found: {model_id}", details={"id": model_id})
+        return model
+
+    def list_procedures(
+        self, *, proc_type: Optional[str] = None, tier: Optional[str] = None
+    ) -> List[ProcedureEntry]:
+        """List procedures, optionally filtered by type or tier."""
+        procedures = list(self.catalog.procedures.values())
+        if proc_type:
+            procedures = [item for item in procedures if item.type == proc_type]
+        if tier:
+            wanted = self._tier(tier)
+            procedures = [item for item in procedures if item.tier == wanted]
+        return procedures
+
+    def get_procedure(self, procedure_id: str) -> ProcedureEntry:
+        """Return one procedure or raise NotFoundError."""
+        procedure = self.catalog.procedures.get(procedure_id)
+        if procedure is None:
+            raise NotFoundError(
+                f"Procedure not found: {procedure_id}", details={"id": procedure_id}
+            )
+        return procedure
+
+    def stats(self) -> Dict[str, Any]:
+        """Return Dex collection statistics."""
+        return self.catalog.calculate_collection_stats()
+
+    async def sync(self, *, force: bool = False) -> Dict[str, Any]:
+        """Refresh Dex from OpenRouter (or an injected syncer) and return stats."""
+        syncer = self._syncer
+        if syncer is None:
+            from zen.dex.openrouter_sync import OpenRouterSync
+
+            syncer = OpenRouterSync()
+            self._syncer = syncer
+        if force:
+            cache_file = getattr(syncer, "cache_file", None)
+            if cache_file is not None and getattr(cache_file, "exists", lambda: False)():
+                cache_file.unlink()
+        await syncer.sync_dex()
+        self.catalog.load_data()
+        return self.stats()

--- a/zen/services/errors.py
+++ b/zen/services/errors.py
@@ -1,0 +1,42 @@
+"""Service-layer errors mapped to zen.error packets."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+class ServiceError(Exception):
+    """Use-case error with HTTP mapping metadata."""
+
+    status_code = 400
+    code = "service_error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: Optional[Mapping[str, Any]] = None,
+        code: Optional[str] = None,
+        status_code: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = dict(details or {})
+        if code is not None:
+            self.code = code
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class NotFoundError(ServiceError):
+    """Requested resource does not exist."""
+
+    status_code = 404
+    code = "not_found"
+
+
+class UnavailableError(ServiceError):
+    """Upstream dependency is missing or misconfigured."""
+
+    status_code = 503
+    code = "unavailable"

--- a/zen/services/inbox.py
+++ b/zen/services/inbox.py
@@ -1,0 +1,53 @@
+"""Inbox capture use cases."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from zen.inbox import InboxManager
+
+
+class InboxService:
+    """Create and list inbox items without Click I/O."""
+
+    def __init__(
+        self, manager: Optional[InboxManager] = None, base_path: Optional[Any] = None
+    ) -> None:
+        if manager is not None:
+            self.manager = manager
+        else:
+            self.manager = InboxManager(str(base_path) if base_path is not None else ".")
+
+    def list_items(self, status: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List inbox items, optionally filtered by status."""
+        return self.manager.list_items(status)
+
+    def add_item(
+        self,
+        item_type: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Capture an inbox item and return the stored record."""
+        item_id = self.manager.add_item(item_type, content, metadata)
+        for item in self.manager.list_items():
+            if item.get("id") == item_id:
+                return item
+        return {
+            "id": item_id,
+            "type": item_type,
+            "content": content,
+            "metadata": metadata or {},
+            "status": "new",
+        }
+
+    def item_fields(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Serialize an inbox item to card fields."""
+        return {
+            "type": item.get("type"),
+            "content": item.get("content"),
+            "metadata": item.get("metadata") or {},
+            "status": item.get("status"),
+            "created_at": item.get("created_at"),
+            "updated_at": item.get("updated_at"),
+        }

--- a/zen/services/plugins.py
+++ b/zen/services/plugins.py
@@ -1,0 +1,77 @@
+"""Plugin catalog and execution use cases."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from zen.plugins.executor import ExecutionContext, ExecutionResult, PluginExecutor
+from zen.plugins.registry import PluginEntry, PluginRegistry
+from zen.services.errors import NotFoundError, ServiceError
+
+
+class PluginService:
+    """List, inspect, and execute Git-based zenOS plugins."""
+
+    def __init__(
+        self,
+        registry: Optional[PluginRegistry] = None,
+        executor: Optional[PluginExecutor] = None,
+    ) -> None:
+        self._registry = registry
+        self._executor = executor
+
+    def _get_registry(self) -> PluginRegistry:
+        if self._registry is None:
+            self._registry = PluginRegistry()
+        return self._registry
+
+    def _get_executor(self) -> PluginExecutor:
+        if self._executor is None:
+            self._executor = PluginExecutor(self._get_registry())
+        return self._executor
+
+    def plugin_fields(self, entry: PluginEntry) -> Dict[str, Any]:
+        """Serialize a plugin registry entry to card fields."""
+        manifest = entry.manifest
+        return {
+            "name": manifest.name,
+            "version": manifest.version,
+            "author": manifest.author,
+            "description": manifest.description,
+            "category": manifest.category,
+            "capabilities": list(manifest.capabilities),
+            "is_active": entry.is_active,
+            "usage_count": entry.usage_count,
+        }
+
+    def list_plugins(self) -> list:
+        """Return installed plugin entries."""
+        return list(self._get_registry().plugins.values())
+
+    def get_plugin(self, plugin_id: str) -> PluginEntry:
+        """Return one plugin or raise NotFoundError."""
+        entry = self._get_registry().get_plugin(plugin_id)
+        if entry is None:
+            raise NotFoundError(f"Plugin not found: {plugin_id}", details={"id": plugin_id})
+        return entry
+
+    async def execute(
+        self,
+        plugin_id: str,
+        procedure_id: str,
+        input_data: Any,
+        context: Optional[ExecutionContext] = None,
+    ) -> ExecutionResult:
+        """Execute a plugin procedure."""
+        self.get_plugin(plugin_id)
+        ctx = context or ExecutionContext(user_id="api", session_id="local", device_info={})
+        result = await self._get_executor().execute_plugin(
+            plugin_id, procedure_id, input_data, ctx
+        )
+        if not result.success:
+            error = result.error or "Plugin execution failed"
+            lowered = error.lower()
+            if "not found" in lowered:
+                raise NotFoundError(error, details={"id": plugin_id, "procedure_id": procedure_id})
+            raise ServiceError(error, details={"id": plugin_id, "procedure_id": procedure_id})
+        return result

--- a/zen/services/plugins.py
+++ b/zen/services/plugins.py
@@ -65,9 +65,7 @@ class PluginService:
         """Execute a plugin procedure."""
         self.get_plugin(plugin_id)
         ctx = context or ExecutionContext(user_id="api", session_id="local", device_info={})
-        result = await self._get_executor().execute_plugin(
-            plugin_id, procedure_id, input_data, ctx
-        )
+        result = await self._get_executor().execute_plugin(plugin_id, procedure_id, input_data, ctx)
         if not result.success:
             error = result.error or "Plugin execution failed"
             lowered = error.lower()

--- a/zen/utils/config.py
+++ b/zen/utils/config.py
@@ -42,6 +42,11 @@ class ZenConfig:
     max_cost_per_request: float = 1.0
     temperature: float = 0.7
 
+    # HTTP API
+    api_host: str = "127.0.0.1"
+    api_port: int = 8080
+    api_token: Optional[str] = None
+
 
 class Config:
     """
@@ -92,6 +97,10 @@ class Config:
         self.config.default_model = os.getenv("ZEN_DEFAULT_MODEL", self.config.default_model)
         self.config.max_tokens = int(os.getenv("ZEN_MAX_TOKENS", "2000"))
         self.config.temperature = float(os.getenv("ZEN_TEMPERATURE", "0.7"))
+
+        self.config.api_host = os.getenv("ZEN_API_HOST", "127.0.0.1")
+        self.config.api_port = int(os.getenv("ZEN_API_PORT", "8080"))
+        self.config.api_token = os.getenv("ZEN_API_TOKEN")
 
     def _load_from_home(self):
         """Load configuration from ~/.zenOS/config.yaml."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Pull Request Description

### Summary
Adds a real machine HTTP interface for zenOS. Click is no longer the only entrypoint: agents, Dex, plugins, inbox, and chat go through shared services, then FastAPI `/api/v1` with generated OpenAPI.

Packet envelope is `zen.packet.v1`: handshake dumps the schema (`POST /api/v1/session`), later stream packets omit unchanged fields. Errors are `zen.error` cards, not bare FastAPI `detail`.

`zen serve` (and the documented `python -m zen.core.api` shim) binds `127.0.0.1:8080` by default. Non-loopback binds require `ZEN_API_TOKEN`. Compose/Dockerfile now expose port 8080.

### Related Issues
Closes #

### Type of Change
- [x] New feature
- [x] Documentation update
- [x] Breaking change (Python floor 3.10+; Docker default CMD is the API)

---

### Testing
- `pytest tests/api tests/test_dex_catalog.py tests/test_dex_reader.py tests/test_dex_bench.py tests/test_no_legacy_branding.py` — 51 passed
- `zen serve --help` and `python -m zen.api --help`

### Documentation
- `docs/guides/REST_API.md`
- README, Termux quickstart, `env.example`

### Other Considerations
- Bearer token required off loopback
- CORS allowlist, never `*`
- OpenRouter key never returned in API bodies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f15530-92c1-4642-9c2f-dc44aab0486c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f15530-92c1-4642-9c2f-dc44aab0486c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

